### PR TITLE
Add custom attribute for server name

### DIFF
--- a/redis-config.yml.sample
+++ b/redis-config.yml.sample
@@ -7,6 +7,7 @@ instances:
       hostname: localhost
       port: 6379
       keys: '{"0":["<KEY_1>"],"1":["<KEY_2>"]}'
+      instancename: myInstance
 
   - name: redis-inventory
     command: inventory

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -73,8 +73,9 @@ var keyspaceMetricsDefinition = map[string][]interface{}{
 
 type manipulator func(map[string]interface{}) (interface{}, bool)
 
-func populateMetrics(sample *metric.MetricSet, metrics map[string]interface{}, definition map[string][]interface{}) error {
+func populateMetrics(sample *metric.MetricSet, instanceName string, metrics map[string]interface{}, definition map[string][]interface{}) error {
 	notFoundMetric := make([]string, 0)
+	sample.SetMetric("server.name", strings.Replace(instanceName, " ", "_", -1), metric.ATTRIBUTE)
 
 	for metricName, metricInfo := range definition {
 		rawSource := metricInfo[0]

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -16,33 +16,33 @@ import (
 )
 
 var expectedRawInfoFromSample = map[string]interface{}{
-	"active_defrag_hits":           0,
-	"active_defrag_key_hits":       0,
-	"active_defrag_key_misses":     0,
-	"active_defrag_misses":         0,
-	"active_defrag_running":        0,
-	"aof_current_rewrite_time_sec": -1,
-	"aof_enabled":                  0,
-	"aof_last_bgrewrite_status":    "ok",
-	"aof_last_cow_size":            0,
-	"aof_last_rewrite_time_sec":    -1,
-	"aof_last_write_status":        "ok",
-	"aof_rewrite_in_progress":      0,
-	"aof_rewrite_scheduled":        0,
-	"arch_bits":                    64,
-	"atomicvar_api":                "atomic-builtin",
-	"blocked_clients":              0,
-	"client_biggest_input_buf":     0,
-	"client_longest_output_list":   0,
-	"cluster_enabled":              0,
-	"config_file":                  "",
-	"connected_clients":            1,
-	"connected_slaves":             0,
-	"evicted_keys":                 0,
-	"executable":                   "/Users/newrelic/redis-server",
-	"expired_keys":                 0,
-	"gcc_version":                  "4.2.1",
-	"hz":                           10,
+	"active_defrag_hits":             0,
+	"active_defrag_key_hits":         0,
+	"active_defrag_key_misses":       0,
+	"active_defrag_misses":           0,
+	"active_defrag_running":          0,
+	"aof_current_rewrite_time_sec":   -1,
+	"aof_enabled":                    0,
+	"aof_last_bgrewrite_status":      "ok",
+	"aof_last_cow_size":              0,
+	"aof_last_rewrite_time_sec":      -1,
+	"aof_last_write_status":          "ok",
+	"aof_rewrite_in_progress":        0,
+	"aof_rewrite_scheduled":          0,
+	"arch_bits":                      64,
+	"atomicvar_api":                  "atomic-builtin",
+	"blocked_clients":                0,
+	"client_biggest_input_buf":       0,
+	"client_longest_output_list":     0,
+	"cluster_enabled":                0,
+	"config_file":                    "",
+	"connected_clients":              1,
+	"connected_slaves":               0,
+	"evicted_keys":                   0,
+	"executable":                     "/Users/newrelic/redis-server",
+	"expired_keys":                   0,
+	"gcc_version":                    "4.2.1",
+	"hz":                             10,
 	"instantaneous_input_kbps":       0.00,
 	"instantaneous_ops_per_sec":      0,
 	"instantaneous_output_kbps":      0.00,
@@ -116,6 +116,7 @@ var expectedRawInfoFromSample = map[string]interface{}{
 	"used_memory_rss_human":          "2.16M",
 	"used_memory_startup":            963200,
 	"rdb_last_cow_size":              0,
+	"server.name":                    "test_instance",
 }
 
 var expectedMetricSetFromSample = metric.MetricSet{
@@ -161,6 +162,7 @@ var expectedMetricSetFromSample = metric.MetricSet{
 	"system.usedMemoryPeakBytes":             1032128,
 	"system.usedMemoryRssBytes":              2260992,
 	"system.memFragmentationRatio":           2.23,
+	"server.name":                            "testInstance",
 }
 
 var expectedRawKeyspaceInfoFromSample = map[string]map[string]interface{}{
@@ -237,7 +239,7 @@ func TestPopulateMetrics(t *testing.T) {
 	integration := sdk.Integration{}
 	ms := integration.NewMetricSet("metricsTestSample")
 
-	err = populateMetrics(ms, rawMetrics, metricsDefinition)
+	err = populateMetrics(ms, "test instance", rawMetrics, metricsDefinition)
 	if err != nil {
 		t.Error(err)
 	}
@@ -248,7 +250,7 @@ func TestPopulateMetrics(t *testing.T) {
 
 	for db, keyspaceMetrics := range rawKeyspace {
 		ms = integration.NewMetricSet(fmt.Sprintf("keyspaceTestSample_%s", db))
-		err = populateMetrics(ms, keyspaceMetrics, keyspaceMetricsDefinition)
+		err = populateMetrics(ms, "testInstance", keyspaceMetrics, keyspaceMetricsDefinition)
 		if err != nil {
 			t.Error(err)
 		}

--- a/src/redis.go
+++ b/src/redis.go
@@ -14,6 +14,7 @@ type argumentList struct {
 	Keys           sdkArgs.JSON `default:"" help:"List of the keys for retrieving their lengths"`
 	KeysLimit      int          `default:"30" help:"Max number of the keys to retrieve their lengths"`
 	Password       string       `help:"Password to use when connecting to the Redis server."`
+	InstanceName   string       `default:"" help:"Friendly identifier of a Redis instance."`
 }
 
 const (
@@ -45,7 +46,7 @@ func main() {
 	if args.All || args.Metrics {
 		fatalIfErr(metricsErr)
 		ms := integration.NewMetricSet("RedisSample")
-		fatalIfErr(populateMetrics(ms, rawMetrics, metricsDefinition))
+		fatalIfErr(populateMetrics(ms, args.InstanceName, rawMetrics, metricsDefinition))
 
 		var rawCustomKeysMetric map[string]map[string]keyInfo
 		keysFlagPresent := args.Keys.Get() != nil
@@ -66,7 +67,7 @@ func main() {
 
 		for db, keyspaceMetrics := range rawKeyspaceMetrics {
 			ms = integration.NewMetricSet("RedisKeyspaceSample")
-			fatalIfErr(populateMetrics(ms, keyspaceMetrics, keyspaceMetricsDefinition))
+			fatalIfErr(populateMetrics(ms, args.InstanceName, keyspaceMetrics, keyspaceMetricsDefinition))
 
 			if _, ok := rawCustomKeysMetric[db]; ok && keysFlagPresent {
 				populateCustomKeysMetric(ms, rawCustomKeysMetric[db])


### PR DESCRIPTION
#### Description of the changes

Hello! This is a different take on the problem I'm trying to solve for in #9. We run multiple instances of redis on a single machine and would like to have a way to differentiate between them in Insights. Historically we've done this with the port number, but specifying a "human friendly" name would work equally well for our purposes.

I'm more than open to other ideas as well, my only real goal is to differentiate between multiple unique redis instances on a single machine

#### PR Review Checklist
### Author

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
