### PR TITLE
Update executable prefix from nr- to nri-.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 (2019-11-18)
+### Changed
+- Renamed the integration executable from nr-redis to nri-redis in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.
 ## 1.2.1 (2019-08-05)
 ## Fixed
 * Omitted `masterauth` inventory entry. It is now submitted as `(omitted entry)`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM golang:1.10 as builder
-RUN go get -d github.com/newrelic/nri-redis/... && \
-    cd /go/src/github.com/newrelic/nri-redis && \
+COPY . /go/src/github.com/newrelic/nri-redis/
+RUN cd /go/src/github.com/newrelic/nri-redis && \
     make compile && \
-    strip ./bin/nr-redis
+    strip ./bin/nri-redis
 
 FROM newrelic/infrastructure:latest
 ENV NRIA_IS_FORWARD_ONLY true
 ENV NRIA_K8S_INTEGRATION true
-COPY --from=builder /go/src/github.com/newrelic/nri-redis/bin/nr-redis /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nr-redis
+COPY --from=builder /go/src/github.com/newrelic/nri-redis/bin/nri-redis /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-redis
 COPY --from=builder /go/src/github.com/newrelic/nri-redis/redis-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/redis-definition.yml
 
 USER 1000

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INTEGRATION     := redis
-BINARY_NAME      = nr-$(INTEGRATION)
+BINARY_NAME      = nri-$(INTEGRATION)
 SRC_DIR          = ./src/
 GO_PKGS         := $(shell go list ./... | grep -v "/vendor/")
 VALIDATE_DEPS    = golang.org/x/lint/golint

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Assuming that you have the source code and Go tool installed (go version 1.9) th
 ```bash
 $ make
 ```
-* The command above will execute the tests for the Redis integration and build an executable file called `nr-redis` under `bin` directory. Run `nr-redis`:
+* The command above will execute the tests for the Redis integration and build an executable file called `nri-redis` under `bin` directory. Run `nri-redis`:
 ```bash
-$ ./bin/nr-redis
+$ ./bin/nri-redis
 ```
-* If you want to know more about usage of `./bin/nr-redis` check
+* If you want to know more about usage of `./bin/nri-redis` check
 ```bash
-$ ./bin/nr-redis -help
+$ ./bin/nri-redis -help
 ```
 
 For managing external dependencies [govendor tool](https://github.com/kardianos/govendor) is used. It is required to lock all external dependencies to specific version (if possible) into vendor directory.
@@ -37,7 +37,7 @@ You can find a configuration sample file called `redis-config.yml.sample` in thi
 
 1. Download the Redis integration.
 2. Copy the `redis-definition.yml` and `/bin` into `/var/db/newrelic-infra/newrelic-integrations`
-3. Add execute permissions for the binary file nr-redis (if required)
+3. Add execute permissions for the binary file nri-redis (if required)
 4. Copy `redis-config.yml` into `/etc/newrelic-infra/integrations.d`
 
 ## Contributing Code

--- a/redis-definition.yml
+++ b/redis-definition.yml
@@ -6,13 +6,13 @@ os: linux
 commands:
   metrics:
     command:
-      - ./bin/nr-redis
+      - ./bin/nri-redis
       - --metrics
     interval: 15
 
   inventory:
     command:
-      - ./bin/nr-redis
+      - ./bin/nri-redis
       - --inventory
     prefix: config/redis
     interval: 60

--- a/src/redis.go
+++ b/src/redis.go
@@ -25,7 +25,7 @@ type argumentList struct {
 
 const (
 	integrationName    = "com.newrelic.redis"
-	integrationVersion = "1.2.1"
+	integrationVersion = "1.3.0"
 	entityRemoteType   = "instance"
 )
 

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - nri-redis
 
   nri-redis:
+    container_name: integration_nri-redis_1
     build:
       context: ../../
       dockerfile: tests/integration/Dockerfile

--- a/tests/integration/helpers/helpers.go
+++ b/tests/integration/helpers/helpers.go
@@ -19,7 +19,7 @@ import (
 // checks if the integration files are placed in the proper directories.
 func CheckIntegrationIsInstalled(iName string) error {
 	iPaths := []string{
-		fmt.Sprintf("/var/db/newrelic-infra/newrelic-integrations/bin/nr-%s", iName),
+		fmt.Sprintf("/var/db/newrelic-infra/newrelic-integrations/bin/nri-%s", iName),
 		fmt.Sprintf("/var/db/newrelic-infra/newrelic-integrations/%s-definition.yml", iName),
 		fmt.Sprintf("/etc/newrelic-infra/integrations.d/%s-config.yml.sample", iName),
 	}

--- a/tests/integration/json-schema-files/output.json
+++ b/tests/integration/json-schema-files/output.json
@@ -1,7 +1,7 @@
 {
   "name": "com.newrelic.redis",
   "protocol_version": "3",
-  "integration_version": "1.2.1",
+  "integration_version": "1.3.0",
   "data": [
     {
       "metrics": [

--- a/tests/integration/json-schema-files/redis-schema-inventory.json
+++ b/tests/integration/json-schema-files/redis-schema-inventory.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.1$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/redis-schema-metrics.json
+++ b/tests/integration/json-schema-files/redis-schema-metrics.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.1$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/redis-schema-remote-entity.json
+++ b/tests/integration/json-schema-files/redis-schema-remote-entity.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.1$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/redis-schema.json
+++ b/tests/integration/json-schema-files/redis-schema.json
@@ -5,7 +5,7 @@
 
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.2.1$",
+      "pattern": "^1.3.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/redis_test.go
+++ b/tests/integration/redis_test.go
@@ -20,7 +20,7 @@ import (
 var (
 	//default values
 	defaultContainer = "integration_nri-redis_1"
-	defaultBinPath   = "/nr-redis"
+	defaultBinPath   = "/nri-redis"
 	defaultHost      = "redis"
 	defaultPort      = 6379
 


### PR DESCRIPTION
### Changed
- Renamed the integration executable from nr-redis to nri-redis in order to be consistent with the package naming. **Important Note:** if you have any security module rules (eg. SELinux), alerts or automation that depends on the name of this binary, these will have to be updated.