### PR TITLE
Modify Entity name when using unix socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 1.5.0 (2020-08-10)
 ### Added
-- `USE_UNIX_SOCKET` configuration option (default: false). Flag to add the UnixSocketPath value to the entity. This will help to uniquely identify your entities when you're monitoring more than one Redis instance on the same host using Unix sockets.
+- `USE_UNIX_SOCKET` configuration option (default: `false`). Adds the `UnixSocketPath` value to the entity. This helps to uniquely identify your entities when you're monitoring more than one Redis instance on the same host using Unix sockets.
   
 ## 1.5.0 (2020-01-13)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.5.0 (2020-08-10)
+### Added
+- `USE_UNIX_SOCKET` configuration option (default: false). Flag to add the UnixSocketPath value to the entity. This will help to uniquely identify your entities when you're monitoring more than one Redis instance on the same host using Unix sockets.
+  
 ## 1.4.0 (2020-01-13)
 ### Added
 - `CONFIG_INVENTORY` configuration option (default: true). Set it to `false` to avoid invoking the Redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `USE_UNIX_SOCKET` configuration option (default: false). Flag to add the UnixSocketPath value to the entity. This will help to uniquely identify your entities when you're monitoring more than one Redis instance on the same host using Unix sockets.
   
-## 1.4.0 (2020-01-13)
+## 1.5.0 (2020-01-13)
 ### Added
 - `CONFIG_INVENTORY` configuration option (default: true). Set it to `false` to avoid invoking the Redis
   `CONFIG` command when querying for inventory data. This option is useful in environments where the Redis

--- a/Makefile-package.mk
+++ b/Makefile-package.mk
@@ -15,7 +15,7 @@ PACKAGE_URL        = "https://www.newrelic.com/infrastructure"
 SUMMARY            = "New Relic Infrastructure $(INTEGRATION) Integration"
 DESCRIPTION        = "New Relic Infrastructure $(INTEGRATION) Integration extend the core New Relic\nInfrastructure agent's capabilities to allow you to collect metric and\nlive state data from your infrastructure $(INTEGRATION) components."
 FPM_COMMON_OPTIONS = --verbose -C $(SOURCE_DIR) -s dir -n $(PROJECT_NAME) -v $(VERSION) --iteration $(RELEASE) --prefix "" --license $(LICENSE) --vendor $(VENDOR) -m $(PACKAGER) --url $(PACKAGE_URL) --config-files /etc/newrelic-infra/ --description "$$(printf $(DESCRIPTION))" --depends "newrelic-infra >= 1.0.726"
-FPM_DEB_OPTIONS    = -t deb -p $(PACKAGES_DIR)/deb/  --replaces "newrelic-infra-integrations (<= 1.4.0-1)"
+FPM_DEB_OPTIONS    = -t deb -p $(PACKAGES_DIR)/deb/  --replaces "newrelic-infra-integrations (<= 1.5.0-1)"
 FPM_RPM_OPTIONS    = -t rpm -p $(PACKAGES_DIR)/rpm/ --epoch 0 --rpm-summary $(SUMMARY)
 
 package: create-bins prep-pkg-env $(PACKAGE_TYPES)

--- a/redis-config.yml.sample
+++ b/redis-config.yml.sample
@@ -16,6 +16,10 @@ instances:
       # versus remote entities:
       # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
       remote_monitoring: true
+
+      # New users should leave this property as `true`, to uniquely identify the monitored entities when using
+      # Unix sockets.
+      use_unix_socket: true
     labels:
       environment: production
 
@@ -33,5 +37,9 @@ instances:
       # versus remote entities:
       # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
       remote_monitoring: true
+
+      # New users should leave this property as `true`, to uniquely identify the monitored entities when using
+      # Unix sockets.
+      use_unix_socket: true
     labels:
       environment: production

--- a/src/redis.go
+++ b/src/redis.go
@@ -20,13 +20,14 @@ type argumentList struct {
 	Keys             sdkArgs.JSON `default:"" help:"List of the keys for retrieving their lengths"`
 	KeysLimit        int          `default:"30" help:"Max number of the keys to retrieve their lengths"`
 	Password         string       `help:"Password to use when connecting to the Redis server."`
+	UseUnixSocket    bool         `default:"false" help:"Flag to add the UnixSocketPath value to the entity. If you are monitoring more than one Redis instance on the same host using Unix sockets, then you should set it to true."`
 	RemoteMonitoring bool         `default:"false" help:"Allows to monitor multiple instances as 'remote' entity. Set to 'FALSE' value for backwards compatibility otherwise set to 'TRUE'"`
 	ConfigInventory  bool         `default:"true" help:"Provides CONFIG inventory information. Set it to 'false' in environments where the Redis CONFIG command is prohibited (e.g. AWS ElastiCache)"`
 }
 
 const (
 	integrationName    = "com.newrelic.redis"
-	integrationVersion = "1.4.0"
+	integrationVersion = "1.5.0"
 	entityRemoteType   = "instance"
 )
 
@@ -137,7 +138,7 @@ func createIntegration() (*integration.Integration, error) {
 func entity(i *integration.Integration, args *argumentList) (*integration.Entity, error) {
 	if args.RemoteMonitoring {
 		var n string
-		if args.UnixSocketPath != "" {
+		if args.UseUnixSocket && args.UnixSocketPath != "" {
 			n = fmt.Sprintf("%s:%s", args.Hostname, args.UnixSocketPath)
 		} else {
 			n = fmt.Sprintf("%s:%d", args.Hostname, args.Port)

--- a/src/redis.go
+++ b/src/redis.go
@@ -136,7 +136,12 @@ func createIntegration() (*integration.Integration, error) {
 
 func entity(i *integration.Integration, args *argumentList) (*integration.Entity, error) {
 	if args.RemoteMonitoring {
-		n := fmt.Sprintf("%s:%d", args.Hostname, args.Port)
+		var n string
+		if args.UnixSocketPath != "" {
+			n = fmt.Sprintf("%s:%s", args.Hostname, args.UnixSocketPath)
+		} else {
+			n = fmt.Sprintf("%s:%d", args.Hostname, args.Port)
+		}
 		return i.Entity(n, entityRemoteType)
 	}
 

--- a/src/redis.go
+++ b/src/redis.go
@@ -20,7 +20,7 @@ type argumentList struct {
 	Keys             sdkArgs.JSON `default:"" help:"List of the keys for retrieving their lengths"`
 	KeysLimit        int          `default:"30" help:"Max number of the keys to retrieve their lengths"`
 	Password         string       `help:"Password to use when connecting to the Redis server."`
-	UseUnixSocket    bool         `default:"false" help:"Flag to add the UnixSocketPath value to the entity. If you are monitoring more than one Redis instance on the same host using Unix sockets, then you should set it to true."`
+	UseUnixSocket    bool         `default:"false" help:"Adds the UnixSocketPath value to the entity. If you are monitoring more than one Redis instance on the same host using Unix sockets, then you should set it to true."`
 	RemoteMonitoring bool         `default:"false" help:"Allows to monitor multiple instances as 'remote' entity. Set to 'FALSE' value for backwards compatibility otherwise set to 'TRUE'"`
 	ConfigInventory  bool         `default:"true" help:"Provides CONFIG inventory information. Set it to 'false' in environments where the Redis CONFIG command is prohibited (e.g. AWS ElastiCache)"`
 }

--- a/src/redis_test.go
+++ b/src/redis_test.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/newrelic/infra-integrations-sdk/integration"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEntity_LocalEntity(t *testing.T) {
@@ -18,7 +19,7 @@ func TestEntity_LocalEntity(t *testing.T) {
 	assert.Nil(t, e.Metadata)
 }
 
-func TestEntity_RemoteEntity(t *testing.T) {
+func TestEntity_RemoteEntityPort(t *testing.T) {
 	args := argumentList{
 		Hostname:         "localhost",
 		Port:             8080,
@@ -30,5 +31,21 @@ func TestEntity_RemoteEntity(t *testing.T) {
 	e, err := entity(i, &args)
 	assert.NoError(t, err)
 	assert.Equal(t, "localhost:8080", e.Metadata.Name)
+	assert.Equal(t, entityRemoteType, e.Metadata.Namespace)
+
+}
+func TestEntity_RemoteEntityUnixSocket(t *testing.T) {
+	args := argumentList{
+		Hostname:         "localhost",
+		Port:             8080,
+		RemoteMonitoring: true,
+		UnixSocketPath:   "/socket/path",
+	}
+	i, err := integration.New("test", integrationVersion)
+	assert.NoError(t, err)
+
+	e, err := entity(i, &args)
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost:/socket/path", e.Metadata.Name)
 	assert.Equal(t, entityRemoteType, e.Metadata.Namespace)
 }

--- a/tests/integration/json-schema-files/output.json
+++ b/tests/integration/json-schema-files/output.json
@@ -1,7 +1,7 @@
 {
   "name": "com.newrelic.redis",
   "protocol_version": "3",
-  "integration_version": "1.4.0",
+  "integration_version": "1.5.0",
   "data": [
     {
       "metrics": [

--- a/tests/integration/json-schema-files/redis-schema-inventory.json
+++ b/tests/integration/json-schema-files/redis-schema-inventory.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^1.5.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/redis-schema-metrics.json
+++ b/tests/integration/json-schema-files/redis-schema-metrics.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^1.5.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/redis-schema-remote-entity.json
+++ b/tests/integration/json-schema-files/redis-schema-remote-entity.json
@@ -4,7 +4,7 @@
   "properties": {
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^1.5.0$",
       "type": "string"
     },
     "data": {

--- a/tests/integration/json-schema-files/redis-schema.json
+++ b/tests/integration/json-schema-files/redis-schema.json
@@ -5,7 +5,7 @@
 
     "integration_version": {
       "minLength": 1,
-      "pattern": "^1.4.0$",
+      "pattern": "^1.5.0$",
       "type": "string"
     },
     "data": {


### PR DESCRIPTION
#### Description of the changes

The entity name is composed by `host:port` even when the connection is by Unix sockets. This caused two issues:
* The entity name is using a port that is not actually related to the instance. 
* Entity name coalition in cases more than one instance of Redis is being scraped in the host.

CHANGE:
When unix_socket is being used to connect to a Redis instance and remote_monitoring is true the entity names will be named `host:unix_socket` instead of `host:port`.

In order to not break compatibility with customers who are already using unix sockets and don't have any issue, we are going to add a new config option to opt-in to the new behaviour when using unix sockets.

#### PR Review Checklist
### Author

- [x] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [x] add unit tests for your changes and make sure all unit tests are passing
- [x] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [x] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
