### PR TITLE
ci: test package installability

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -136,6 +136,11 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ env.SLACK_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
           slack-text: ":shit: Repo: ${{ env.REPO_FULL_NAME }}, prerelease for nix FAILURE!"
+      - name: Test package installability
+        uses: newrelic/integrations-pkg-test-action/linux@v1
+        with:
+          tag: ${{ env.TAG }}
+          integration: nri-${{ env.INTEGRATION }}
 
   package-win:
     name: Create MSI & Upload into GH Release assets

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -154,6 +154,10 @@ jobs:
     strategy:
       matrix:
         goarch: [amd64,386]
+        test-upgrade: [true,false]
+        exclude:
+          - goarch: 386
+            test-upgrade: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -170,7 +174,15 @@ jobs:
         shell: pwsh
         run: |
           build\windows\package_msi.ps1 -integration "$env:INTEGRATION" -arch ${{ matrix.goarch }} -tag "$env:TAG" -pfx_passphrase "$env:PFX_PASSPHRASE" -pfx_certificate_description "$env:PFX_CERTIFICATE_DESCRIPTION"
+      - name: Test win packages installation
+        uses: newrelic/integrations-pkg-test-action/windows@v1
+        with:
+          tag: ${{ env.TAG }}
+          integration: nri-${{ env.INTEGRATION }}
+          arch: ${{ matrix.goarch }}
+          upgrade: ${{ matrix.test-upgrade }}
       - name: Upload MSI to GH
+        if: startsWith(matrix.test-upgrade, 'false')
         shell: bash
         run: |
           build/windows/upload_msi.sh ${INTEGRATION} ${{ matrix.goarch }} ${TAG}


### PR DESCRIPTION
This PR adds package installability to the prerelease pipeline with [coreint's new action](https://github.com/paologallinaharbur/test-packages-action)