### PR TITLE
Allows Usages of rename-command on Redis Server Installation

### DIFF
--- a/redis-config.yml.k8s_sample
+++ b/redis-config.yml.k8s_sample
@@ -19,5 +19,10 @@
           PORT: 6379
           KEYS: '{"0":["<KEY_1>"],"1":["<KEY_2>"]}'
           REMOTE_MONITORING: true
+
+          # Rename certain commands according to Redis server's rename-command configuration
+          # Example config entry in /etc/redis/redis-server.conf:
+          #   rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
+          # RENAMED_COMMANDS: '{"CONFIG":"b840fc02d524045429941cc15f59e41cb7be6c52"}'
         labels:
           env: production

--- a/redis-config.yml.sample
+++ b/redis-config.yml.sample
@@ -20,6 +20,12 @@ instances:
       # New users should leave this property as `true`, to uniquely identify the monitored entities when using
       # Unix sockets.
       use_unix_socket: true
+
+      # Rename certain commands according to Redis server's rename-command configuration
+      # Example config entry in /etc/redis/redis-server.conf:
+      #   rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
+      # Users may want to set this config if Redis server is using 'rename-command', to ensure nri-redis functionality
+      # renamed_commands: '{"CONFIG":"b840fc02d524045429941cc15f59e41cb7be6c52"}'
     labels:
       environment: production
 
@@ -41,5 +47,11 @@ instances:
       # New users should leave this property as `true`, to uniquely identify the monitored entities when using
       # Unix sockets.
       use_unix_socket: true
+
+      # Rename certain commands according to Redis server's rename-command configuration
+      # Example config entry in /etc/redis/redis-server.conf:
+      #   rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
+      # Users may want to set this config if Redis server is using 'rename-command', to ensure nri-redis functionality
+      # renamed_commands: '{"CONFIG":"b840fc02d524045429941cc15f59e41cb7be6c52"}'
     labels:
       environment: production

--- a/src/args.go
+++ b/src/args.go
@@ -7,7 +7,7 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/log"
 )
 
-func getDbAndKeys(keysFlag sdkArgs.JSON) map[string][]string {
+func getDBAndKeys(keysFlag sdkArgs.JSON) map[string][]string {
 	databaseKeys := make(map[string][]string)
 
 	convertF := func(listInterface []interface{}) []string {

--- a/src/args.go
+++ b/src/args.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+
+	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
+	"github.com/newrelic/infra-integrations-sdk/log"
+)
+
+func getDbAndKeys(keysFlag sdkArgs.JSON) map[string][]string {
+	databaseKeys := make(map[string][]string)
+
+	convertF := func(listInterface []interface{}) []string {
+		listString := make([]string, 0)
+		for _, elem := range listInterface {
+			if _, ok := elem.(string); ok {
+				listString = append(listString, elem.(string))
+			} else {
+				log.Warn("Not expected type for key: %v, string type required", elem)
+			}
+		}
+		return listString
+	}
+
+	switch source := keysFlag.Get().(type) {
+	case []interface{}:
+		databaseKeys["0"] = removeDuplicates(convertF(source))
+	case map[string]interface{}:
+		for db, keys := range source {
+			databaseKeys[db] = removeDuplicates(convertF(keys.([]interface{})))
+		}
+	default:
+		log.Warn("Invalid format, value of keys flag: %v ", keysFlag)
+	}
+	return databaseKeys
+}
+
+// getRenamedCommands returns a map containing command and renamed command pairs
+// Example flag value: '{"CONFIG":"ZmtlbmZ3ZWZl-CONFIG"}'
+func getRenamedCommands(renamedCommandsFlag sdkArgs.JSON) (map[string]string, error) {
+	renamedCommands := make(map[string]string)
+
+	convertF := func(stringInterface interface{}) (string, error) {
+		str := ""
+		if _, ok := stringInterface.(string); ok {
+			str = stringInterface.(string)
+		} else {
+			return "", fmt.Errorf("Not expected type for key: %v, string type required", stringInterface)
+		}
+		return str, nil
+	}
+
+	switch source := renamedCommandsFlag.Get().(type) {
+	case map[string]interface{}:
+		for cmd, alias := range source {
+			if renamedCmd, err := convertF(alias); err == nil {
+				renamedCommands[cmd] = renamedCmd
+			} else {
+				log.Warn("Invalid format, value of a renamed command: %v=%v", cmd, alias)
+			}
+		}
+	default:
+		return renamedCommands, fmt.Errorf("Invalid format, value of renamed commands flag: %v", renamedCommandsFlag)
+	}
+
+	return renamedCommands, nil
+}
+
+func removeDuplicates(elements []string) []string {
+	found := map[string]struct{}{}
+	result := []string{}
+
+	for v := range elements {
+		if _, ok := found[elements[v]]; !ok {
+			found[elements[v]] = struct{}{}
+			result = append(result, elements[v])
+		}
+	}
+	return result
+}
+
+func validateKeysFlag(databaseKeys map[string][]string, keysLimit int) (int, error) {
+	keysNumber := 0
+	for _, keys := range databaseKeys {
+		keysNumber += len(keys)
+	}
+	if keysNumber > keysLimit {
+		return keysNumber, fmt.Errorf("Keys limit was exceeded; keys limit: %d, keys number: %d", keysNumber, keysLimit)
+	}
+	return keysNumber, nil
+}

--- a/src/args.go
+++ b/src/args.go
@@ -36,18 +36,15 @@ func getDbAndKeys(keysFlag sdkArgs.JSON) map[string][]string {
 }
 
 // getRenamedCommands returns a map containing command and renamed command pairs
-// Example flag value: '{"CONFIG":"ZmtlbmZ3ZWZl-CONFIG"}'
+// Example flag value: '{"CONFIG": "ZmtlbmZ3ZWZl-CONFIG", "ANOTHER-COMMAND": ""}'
 func getRenamedCommands(renamedCommandsFlag sdkArgs.JSON) (map[string]string, error) {
 	renamedCommands := make(map[string]string)
 
 	convertF := func(stringInterface interface{}) (string, error) {
-		str := ""
-		if _, ok := stringInterface.(string); ok {
-			str = stringInterface.(string)
-		} else {
-			return "", fmt.Errorf("Not expected type for key: %v, string type required", stringInterface)
+		if str, ok := stringInterface.(string); ok {
+			return str, nil
 		}
-		return str, nil
+		return "", fmt.Errorf("Unexpected type %T, value must be a string", stringInterface)
 	}
 
 	switch source := renamedCommandsFlag.Get().(type) {

--- a/src/args_test.go
+++ b/src/args_test.go
@@ -15,7 +15,7 @@ func TestGetDbAndKeys(t *testing.T) {
 		"2": {"key2", "key3"},
 	}
 
-	databaseKey := getDbAndKeys(*keysFlag)
+	databaseKey := getDBAndKeys(*keysFlag)
 	if !reflect.DeepEqual(databaseKey, expectedValue) {
 		t.Error()
 	}
@@ -26,7 +26,7 @@ func TestGetDbAndKeysDb0(t *testing.T) {
 	expectedValue := map[string][]string{
 		"0": {"key1", "key2"},
 	}
-	databaseKey := getDbAndKeys(*keysFlag)
+	databaseKey := getDBAndKeys(*keysFlag)
 	if !reflect.DeepEqual(databaseKey, expectedValue) {
 		t.Error()
 	}
@@ -35,7 +35,7 @@ func TestGetDbAndKeysDb0(t *testing.T) {
 func TestGetDbAndKeysEmpty(t *testing.T) {
 	keysFlag := sdkArgs.NewJSON(nil)
 
-	databaseKey := getDbAndKeys(*keysFlag)
+	databaseKey := getDBAndKeys(*keysFlag)
 	if len(databaseKey) != 0 {
 		t.Error()
 	}

--- a/src/args_test.go
+++ b/src/args_test.go
@@ -92,3 +92,52 @@ func TestValidateKeysFlagExceedLimit(t *testing.T) {
 		t.Error()
 	}
 }
+
+func Test_getRenamedCommands(t *testing.T) {
+	type args struct {
+		renamedCommandsFlag sdkArgs.JSON
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			"Rename one command",
+			args{*sdkArgs.NewJSON(map[string]interface{}{"CONFIG": "ZmtlbmZ3ZWZl-CONFIG"})},
+			map[string]string{"CONFIG": "ZmtlbmZ3ZWZl-CONFIG"},
+			false,
+		},
+		{
+			"Rename multiple commands",
+			args{*sdkArgs.NewJSON(map[string]interface{}{"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND", "RENAMED-CONFIG": "NEW-RENAMED-CONFIG"})},
+			map[string]string{"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND", "RENAMED-CONFIG": "NEW-RENAMED-CONFIG"},
+			false,
+		},
+		{
+			"An invalid renamed command value should be skipped",
+			args{*sdkArgs.NewJSON(map[string]interface{}{"RENAMED-COMMAND": 1})},
+			map[string]string{},
+			false,
+		},
+		{
+			"An invalid renamed command key should return error",
+			args{*sdkArgs.NewJSON(map[int]interface{}{1: "RENAMED-COMMAND"})},
+			map[string]string{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getRenamedCommands(tt.args.renamedCommandsFlag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getRenamedCommands() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getRenamedCommands() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/args_test.go
+++ b/src/args_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDbAndKeys(t *testing.T) {
+	keysFlag := sdkArgs.NewJSON(map[string]interface{}{"0": []interface{}{"key1"}, "2": []interface{}{"key2", "key3"}})
+	expectedValue := map[string][]string{
+		"0": {"key1"},
+		"2": {"key2", "key3"},
+	}
+
+	databaseKey := getDbAndKeys(*keysFlag)
+	if !reflect.DeepEqual(databaseKey, expectedValue) {
+		t.Error()
+	}
+}
+
+func TestGetDbAndKeysDb0(t *testing.T) {
+	keysFlag := sdkArgs.NewJSON([]interface{}{"key1", "key2"})
+	expectedValue := map[string][]string{
+		"0": {"key1", "key2"},
+	}
+	databaseKey := getDbAndKeys(*keysFlag)
+	if !reflect.DeepEqual(databaseKey, expectedValue) {
+		t.Error()
+	}
+}
+
+func TestGetDbAndKeysEmpty(t *testing.T) {
+	keysFlag := sdkArgs.NewJSON(nil)
+
+	databaseKey := getDbAndKeys(*keysFlag)
+	if len(databaseKey) != 0 {
+		t.Error()
+	}
+}
+
+func TestRemoveDuplicates(t *testing.T) {
+	elements := []string{"k1", "k2", "k1", "k2", "k2", "k3"}
+	expectedElements := []string{"k1", "k2", "k3"}
+
+	result := removeDuplicates(elements)
+	if !reflect.DeepEqual(result, expectedElements) {
+		t.Error()
+	}
+}
+
+func TestRemoveDuplicatesNoDuplicates(t *testing.T) {
+	elements := []string{"k1", "k2", "k3"}
+	expectedElements := []string{"k1", "k2", "k3"}
+
+	result := removeDuplicates(elements)
+	if !reflect.DeepEqual(result, expectedElements) {
+		t.Error()
+	}
+}
+
+func TestValidateKeysFlag(t *testing.T) {
+	databaseKeys := map[string][]string{
+		"0": {"key1", "key2", "key3"},
+	}
+	keysLimit := 3
+	expectedKeysNumber := 3
+
+	keysNumber, err := validateKeysFlag(databaseKeys, keysLimit)
+	assert.NoError(t, err)
+
+	if keysNumber != expectedKeysNumber {
+		t.Error()
+	}
+}
+
+func TestValidateKeysFlagExceedLimit(t *testing.T) {
+	databaseKeys := map[string][]string{
+		"0": {"key1", "key2", "key3"},
+	}
+	keysLimit := 2
+	expectedKeysNumber := 3
+
+	keysNumber, err := validateKeysFlag(databaseKeys, keysLimit)
+
+	if reflect.DeepEqual(err.Error(), "Keys limit was exeeded; keys limit: 2, keys number: %3") {
+		t.Error()
+	}
+	if keysNumber != expectedKeysNumber {
+		t.Error()
+	}
+}

--- a/src/args_test.go
+++ b/src/args_test.go
@@ -111,8 +111,16 @@ func Test_getRenamedCommands(t *testing.T) {
 		},
 		{
 			"Rename multiple commands",
-			args{*sdkArgs.NewJSON(map[string]interface{}{"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND", "RENAMED-CONFIG": "NEW-RENAMED-CONFIG"})},
-			map[string]string{"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND", "RENAMED-CONFIG": "NEW-RENAMED-CONFIG"},
+			args{
+				*sdkArgs.NewJSON(map[string]interface{}{
+					"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND",
+					"RENAMED-CONFIG":      "NEW-RENAMED-CONFIG"},
+				),
+			},
+			map[string]string{
+				"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND",
+				"RENAMED-CONFIG":      "NEW-RENAMED-CONFIG",
+			},
 			false,
 		},
 		{

--- a/src/args_test.go
+++ b/src/args_test.go
@@ -104,6 +104,12 @@ func Test_getRenamedCommands(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			"An empty renamed command should be fine",
+			args{*sdkArgs.NewJSON(map[string]interface{}{})},
+			map[string]string{},
+			false,
+		},
+		{
 			"Rename one command",
 			args{*sdkArgs.NewJSON(map[string]interface{}{"CONFIG": "ZmtlbmZ3ZWZl-CONFIG"})},
 			map[string]string{"CONFIG": "ZmtlbmZ3ZWZl-CONFIG"},
@@ -113,13 +119,15 @@ func Test_getRenamedCommands(t *testing.T) {
 			"Rename multiple commands",
 			args{
 				*sdkArgs.NewJSON(map[string]interface{}{
-					"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND",
-					"RENAMED-CONFIG":      "NEW-RENAMED-CONFIG"},
+					"NON-RENAMED-COMMAND":    "NON-RENAMED-COMMAND",
+					"RENAMED-CONFIG":         "NEW-RENAMED-CONFIG",
+					"ANOTHER-RENAMED-CONFIG": "ANOTHER-RENAMED-CONFIG"},
 				),
 			},
 			map[string]string{
-				"NON-RENAMED-COMMAND": "NON-RENAMED-COMMAND",
-				"RENAMED-CONFIG":      "NEW-RENAMED-CONFIG",
+				"NON-RENAMED-COMMAND":    "NON-RENAMED-COMMAND",
+				"RENAMED-CONFIG":         "NEW-RENAMED-CONFIG",
+				"ANOTHER-RENAMED-CONFIG": "ANOTHER-RENAMED-CONFIG",
 			},
 			false,
 		},

--- a/src/connection.go
+++ b/src/connection.go
@@ -71,10 +71,7 @@ func newRedisCon(hostname string, port int, unixSocket string, password string) 
 		return nil, fmt.Errorf("Redis connection failed, cannot connect either through TCP or Unix Socket")
 	}
 
-	return redisConn{
-		c:               c,
-		renamedCommands: make(map[string]string),
-	}, nil
+	return redisConn{c, nil}, nil
 }
 
 func (r redisConn) GetInfo() (string, error) {
@@ -99,9 +96,7 @@ func (r redisConn) GetConfig() (map[string]string, error) {
 
 // RenameCommands will populate internal renamedCommands mapping
 func (r redisConn) RenameCommands(renamedCommands map[string]string) {
-	if renamedCommands != nil {
-		r.renamedCommands = renamedCommands
-	}
+	r.renamedCommands = renamedCommands
 }
 
 func (r redisConn) Close() {

--- a/src/connection.go
+++ b/src/connection.go
@@ -43,7 +43,6 @@ func (c configConnectionError) Error() string {
 }
 
 func newRedisCon(hostname string, port int, unixSocket string, password string, renamedCommands map[string]string) (conn, error) {
-
 	connectTimeout := redis.DialConnectTimeout(time.Second * 5)
 	readTimeout := redis.DialReadTimeout(time.Second * 5)
 	writeTimeout := redis.DialWriteTimeout(time.Second * 5)

--- a/src/connection_test.go
+++ b/src/connection_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,3 +39,50 @@ func (f fakeConn) Err() error                                         { return n
 func (f fakeConn) Do(_ string, _ ...interface{}) (interface{}, error) { return nil, nil }
 func (f fakeConn) Flush() error                                       { return nil }
 func (f fakeConn) Receive() (interface{}, error)                      { return nil, nil }
+
+func Test_redisConn_getCommand(t *testing.T) {
+	renamedCommands := make(map[string]string)
+	renamedCommands["NON-RENAMED-COMMAND"] = "NON-RENAMED-COMMAND"
+	renamedCommands["RENAMED-CONFIG"] = "NEW-RENAMED-CONFIG"
+	renamedCommands["DISABLED-COMMAND"] = ""
+
+	c := redisConn{c: fakeConn{}, renamedCommands: renamedCommands}
+
+	type fields struct {
+		c redisConn
+	}
+	type args struct {
+		command string
+	}
+	type testcase struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}
+	// Test cases
+	tests := []testcase{}
+	for cmd, alias := range renamedCommands {
+		tests = append(tests, testcase{
+			fmt.Sprintf("rename-command %v %v", cmd, alias),
+			fields{c},
+			args{cmd},
+			alias,
+		})
+	}
+	// Extra test case where the command is not specified the renamedCommands
+	tests = append(tests, testcase{
+		"rename-command UNSPECIFIED UNSPECIFIED",
+		fields{c},
+		args{"UNSPECIFIED"},
+		"UNSPECIFIED",
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fields.c.getCommand(tt.args.command); got != tt.want {
+				t.Errorf("redisConn.getCommand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/src/connection_test.go
+++ b/src/connection_test.go
@@ -40,7 +40,7 @@ func (f fakeConn) Do(_ string, _ ...interface{}) (interface{}, error) { return n
 func (f fakeConn) Flush() error                                       { return nil }
 func (f fakeConn) Receive() (interface{}, error)                      { return nil, nil }
 
-func Test_redisConn_getCommand(t *testing.T) {
+func Test_redisConn_command(t *testing.T) {
 	renamedCommands := make(map[string]string)
 	renamedCommands["NON-RENAMED-COMMAND"] = "NON-RENAMED-COMMAND"
 	renamedCommands["RENAMED-CONFIG"] = "NEW-RENAMED-CONFIG"
@@ -80,8 +80,8 @@ func Test_redisConn_getCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.fields.c.getCommand(tt.args.command); got != tt.want {
-				t.Errorf("redisConn.getCommand() = %v, want %v", got, tt.want)
+			if got := tt.fields.c.command(tt.args.command); got != tt.want {
+				t.Errorf("redisConn.command() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/src/connection_test.go
+++ b/src/connection_test.go
@@ -41,12 +41,12 @@ func (f fakeConn) Flush() error                                       { return n
 func (f fakeConn) Receive() (interface{}, error)                      { return nil, nil }
 
 func Test_redisConn_command(t *testing.T) {
-	renamedCommands := make(map[string]string)
-	renamedCommands["NON-RENAMED-COMMAND"] = "NON-RENAMED-COMMAND"
-	renamedCommands["RENAMED-CONFIG"] = "NEW-RENAMED-CONFIG"
-	renamedCommands["DISABLED-COMMAND"] = ""
+	renamedCommandsTestCase := make(map[string]string)
+	renamedCommandsTestCase["NON-RENAMED-COMMAND"] = "NON-RENAMED-COMMAND"
+	renamedCommandsTestCase["RENAMED-CONFIG"] = "NEW-RENAMED-CONFIG"
+	renamedCommandsTestCase["DISABLED-COMMAND"] = ""
 
-	c := redisConn{c: fakeConn{}, renamedCommands: renamedCommands}
+	c := redisConn{c: fakeConn{}, renamedCommands: renamedCommandsTestCase}
 
 	type fields struct {
 		c redisConn
@@ -62,7 +62,7 @@ func Test_redisConn_command(t *testing.T) {
 	}
 	// Test cases
 	tests := []testcase{}
-	for cmd, alias := range renamedCommands {
+	for cmd, alias := range renamedCommandsTestCase {
 		tests = append(tests, testcase{
 			fmt.Sprintf("rename-command %v %v", cmd, alias),
 			fields{c},
@@ -70,13 +70,6 @@ func Test_redisConn_command(t *testing.T) {
 			alias,
 		})
 	}
-	// Extra test case where the command is not specified the renamedCommands
-	tests = append(tests, testcase{
-		"rename-command UNSPECIFIED UNSPECIFIED",
-		fields{c},
-		args{"UNSPECIFIED"},
-		"UNSPECIFIED",
-	})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/log"
 )
@@ -202,89 +201,6 @@ func populateCustomKeysMetric(sample *metric.Set, rawCustomKeys map[string]keyIn
 			log.Warn("Error setting value: %s", err)
 		}
 	}
-}
-
-func getDbAndKeys(keysFlag sdkArgs.JSON) map[string][]string {
-	databaseKeys := make(map[string][]string)
-
-	convertF := func(listInterface []interface{}) []string {
-		listString := make([]string, 0)
-		for _, elem := range listInterface {
-			if _, ok := elem.(string); ok {
-				listString = append(listString, elem.(string))
-			} else {
-				log.Warn("Not expected type for key: %v, string type required", elem)
-			}
-		}
-		return listString
-	}
-
-	switch source := keysFlag.Get().(type) {
-	case []interface{}:
-		databaseKeys["0"] = removeDuplicates(convertF(source))
-	case map[string]interface{}:
-		for db, keys := range source {
-			databaseKeys[db] = removeDuplicates(convertF(keys.([]interface{})))
-		}
-	default:
-		log.Warn("Invalid format, value of keys flag: %v ", keysFlag)
-	}
-	return databaseKeys
-}
-
-// getRenamedCommands returns a map containing command and renamed command pairs
-// Example flag value: '{"CONFIG":"ZmtlbmZ3ZWZl-CONFIG"}'
-func getRenamedCommands(renamedCommandsFlag sdkArgs.JSON) (map[string]string, error) {
-	renamedCommands := make(map[string]string)
-
-	convertF := func(stringInterface interface{}) (string, error) {
-		str := ""
-		if _, ok := stringInterface.(string); ok {
-			str = stringInterface.(string)
-		} else {
-			return "", fmt.Errorf("Not expected type for key: %v, string type required", stringInterface)
-		}
-		return str, nil
-	}
-
-	switch source := renamedCommandsFlag.Get().(type) {
-	case map[string]interface{}:
-		for cmd, alias := range source {
-			if renamedCmd, err := convertF(alias); err == nil {
-				renamedCommands[cmd] = renamedCmd
-			} else {
-				log.Warn("Invalid format, value of a renamed command: %v=%v", cmd, alias)
-			}
-		}
-	default:
-		return renamedCommands, fmt.Errorf("Invalid format, value of renamed commands flag: %v", renamedCommandsFlag)
-	}
-
-	return renamedCommands, nil
-}
-
-func removeDuplicates(elements []string) []string {
-	found := map[string]struct{}{}
-	result := []string{}
-
-	for v := range elements {
-		if _, ok := found[elements[v]]; !ok {
-			found[elements[v]] = struct{}{}
-			result = append(result, elements[v])
-		}
-	}
-	return result
-}
-
-func validateKeysFlag(databaseKeys map[string][]string, keysLimit int) (int, error) {
-	keysNumber := 0
-	for _, keys := range databaseKeys {
-		keysNumber += len(keys)
-	}
-	if keysNumber > keysLimit {
-		return keysNumber, fmt.Errorf("Keys limit was exceeded; keys limit: %d, keys number: %d", keysNumber, keysLimit)
-	}
-	return keysNumber, nil
 }
 
 func microsecondsToMilliseconds(source string) manipulator {

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -232,6 +232,32 @@ func getDbAndKeys(keysFlag sdkArgs.JSON) map[string][]string {
 	return databaseKeys
 }
 
+// getRenamedCommands returns a map of command and renamed command pair
+// Example: '{"CONFIG":"ZmtlbmZ3ZWZl-CONFIG"}'
+func getRenamedCommands(renamedCommandsFlag sdkArgs.JSON) map[string]string {
+	renamedCommands := make(map[string]string)
+
+	convertF := func(stringInterface interface{}) string {
+		str := ""
+		if _, ok := stringInterface.(string); ok {
+			str = stringInterface.(string)
+		} else {
+			log.Warn("Not expected type for key: %v, string type required", stringInterface)
+		}
+		return str
+	}
+
+	switch source := renamedCommandsFlag.Get().(type) {
+	case map[string]interface{}:
+		for cmd, alias := range source {
+			renamedCommands[cmd] = convertF(alias)
+		}
+	default:
+		log.Warn("Invalid format, value of keys flag: %v ", renamedCommandsFlag)
+	}
+	return renamedCommands
+}
+
 func removeDuplicates(elements []string) []string {
 	found := map[string]struct{}{}
 	result := []string{}

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -13,8 +13,6 @@ import (
 	"os"
 
 	"reflect"
-
-	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 )
 
 var expectedRawInfoFromSample = map[string]interface{}{
@@ -338,91 +336,6 @@ func TestParseKeyspaceMetricsNoMatch(t *testing.T) {
 		t.Errorf("Not all values processed, got %d length of the rawInventory, expected: %d", len(metrics), expectedLength)
 	}
 	if !reflect.DeepEqual(metrics, expectedMetrics) {
-		t.Error()
-	}
-}
-
-func TestGetDbAndKeys(t *testing.T) {
-	keysFlag := sdkArgs.NewJSON(map[string]interface{}{"0": []interface{}{"key1"}, "2": []interface{}{"key2", "key3"}})
-	expectedValue := map[string][]string{
-		"0": {"key1"},
-		"2": {"key2", "key3"},
-	}
-
-	databaseKey := getDbAndKeys(*keysFlag)
-	if !reflect.DeepEqual(databaseKey, expectedValue) {
-		t.Error()
-	}
-}
-
-func TestGetDbAndKeysDb0(t *testing.T) {
-	keysFlag := sdkArgs.NewJSON([]interface{}{"key1", "key2"})
-	expectedValue := map[string][]string{
-		"0": {"key1", "key2"},
-	}
-	databaseKey := getDbAndKeys(*keysFlag)
-	if !reflect.DeepEqual(databaseKey, expectedValue) {
-		t.Error()
-	}
-}
-
-func TestGetDbAndKeysEmpty(t *testing.T) {
-	keysFlag := sdkArgs.NewJSON(nil)
-
-	databaseKey := getDbAndKeys(*keysFlag)
-	if len(databaseKey) != 0 {
-		t.Error()
-	}
-}
-
-func TestRemoveDuplicates(t *testing.T) {
-	elements := []string{"k1", "k2", "k1", "k2", "k2", "k3"}
-	expectedElements := []string{"k1", "k2", "k3"}
-
-	result := removeDuplicates(elements)
-	if !reflect.DeepEqual(result, expectedElements) {
-		t.Error()
-	}
-}
-
-func TestRemoveDuplicatesNoDuplicates(t *testing.T) {
-	elements := []string{"k1", "k2", "k3"}
-	expectedElements := []string{"k1", "k2", "k3"}
-
-	result := removeDuplicates(elements)
-	if !reflect.DeepEqual(result, expectedElements) {
-		t.Error()
-	}
-}
-
-func TestValidateKeysFlag(t *testing.T) {
-	databaseKeys := map[string][]string{
-		"0": {"key1", "key2", "key3"},
-	}
-	keysLimit := 3
-	expectedKeysNumber := 3
-
-	keysNumber, err := validateKeysFlag(databaseKeys, keysLimit)
-	assert.NoError(t, err)
-
-	if keysNumber != expectedKeysNumber {
-		t.Error()
-	}
-}
-
-func TestValidateKeysFlagExceedLimit(t *testing.T) {
-	databaseKeys := map[string][]string{
-		"0": {"key1", "key2", "key3"},
-	}
-	keysLimit := 2
-	expectedKeysNumber := 3
-
-	keysNumber, err := validateKeysFlag(databaseKeys, keysLimit)
-
-	if reflect.DeepEqual(err.Error(), "Keys limit was exeeded; keys limit: 2, keys number: %3") {
-		t.Error()
-	}
-	if keysNumber != expectedKeysNumber {
 		t.Error()
 	}
 }

--- a/src/redis.go
+++ b/src/redis.go
@@ -110,7 +110,7 @@ func main() {
 		keysFlagPresent := args.Keys.Get() != nil
 
 		if keysFlagPresent {
-			databaseKeys := getDbAndKeys(args.Keys)
+			databaseKeys := getDBAndKeys(args.Keys)
 			_, keysFlagErr := validateKeysFlag(databaseKeys, args.KeysLimit)
 
 			if keysFlagErr != nil {

--- a/src/redis.go
+++ b/src/redis.go
@@ -27,6 +27,7 @@ type argumentList struct {
 	Password         string       `help:"Password to use when connecting to the Redis server."`
 	UseUnixSocket    bool         `default:"false" help:"Adds the UnixSocketPath value to the entity. If you are monitoring more than one Redis instance on the same host using Unix sockets, then you should set it to true."`
 	RemoteMonitoring bool         `default:"false" help:"Allows to monitor multiple instances as 'remote' entity. Set to 'FALSE' value for backwards compatibility otherwise set to 'TRUE'"`
+	RenamedCommands  sdkArgs.JSON `default:"" help:"List of Redis commands that are configured with rename-command"`
 	ConfigInventory  bool         `default:"true" help:"Provides CONFIG inventory information. Set it to 'false' in environments where the Redis CONFIG command is prohibited (e.g. AWS ElastiCache)"`
 	ShowVersion      bool         `default:"false" help:"Print build information and exit"`
 }
@@ -59,7 +60,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	conn, err := newRedisCon(args.Hostname, args.Port, args.UnixSocketPath, args.Password)
+	renamedCommands := make(map[string]string)
+	if args.RenamedCommands.Get() != nil {
+		renamedCommands = getRenamedCommands(args.RenamedCommands)
+		log.Debug("Parsed renamed redis commands: %#v", renamedCommands)
+	}
+
+	conn, err := newRedisCon(args.Hostname, args.Port, args.UnixSocketPath, args.Password, renamedCommands)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Redis supports [Disabling of specific commands](https://redis.io/topics/security) where certain commands may get renamed or disabled entirely.

This PR allows users to set `renamed_commands` nri-redis configuration and the config follows existing [keys](https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/redis-monitoring-integration/#keyspace-config) configuration format: `keys: '{"0":["KEY_1"],"1":["KEY_2"]}'` where it accepts a one-liner JSON string.

It tells nri-redis to use the renamed version of certain Redis commands whenever it needs to execute Redis Commands.

Example:
```yaml
  renamed_commands: '{"CONFIG": "ZmtlbmZ3ZWZl-CONFIG"}'
```

Closes #114 

Let me know if the change of function interface for `newRedisCon(...)` in [redis.go](https://github.com/newrelic/nri-redis/blob/0e426a97438135950aa7c1e14136786b387ea71b/src/connection.go#L38) is unacceptable.