### PR TITLE
Support TLS connections to Redis

### DIFF
--- a/src/connection.go
+++ b/src/connection.go
@@ -44,11 +44,14 @@ func (c configConnectionError) Error() string {
 	return "can't execute redis 'CONFIG' command: " + c.cause.Error()
 }
 
-func newRedisCon(hostname string, port int, unixSocket string, password string) (conn, error) {
+func newRedisCon(hostname string, port int, unixSocket string, password string, useTLS bool, skipTLSVerify bool) (conn, error) {
 	connectTimeout := redis.DialConnectTimeout(time.Second * 5)
 	readTimeout := redis.DialReadTimeout(time.Second * 5)
 	writeTimeout := redis.DialWriteTimeout(time.Second * 5)
 	redisPass := redis.DialPassword(password)
+	redisTLSTimeout := redis.DialTLSHandshakeTimeout(time.Second * 5)
+	redisUseTLS := redis.DialUseTLS(useTLS)
+	redisSkipTLSVerify := redis.DialTLSSkipVerify(skipTLSVerify)
 
 	var c redis.Conn
 	var err error
@@ -62,7 +65,7 @@ func newRedisCon(hostname string, port int, unixSocket string, password string) 
 		log.Debug("Connected to Redis through Unix Socket")
 	case hostname != "" && port > 0:
 		URL := hostname + ":" + strconv.Itoa(port)
-		c, err = redis.Dial("tcp", URL, connectTimeout, readTimeout, writeTimeout, redisPass)
+		c, err = redis.Dial("tcp", URL, connectTimeout, readTimeout, writeTimeout, redisPass, redisTLSTimeout, redisUseTLS, redisSkipTLSVerify)
 		if err != nil {
 			return nil, fmt.Errorf("Redis connection through TCP failed, got error: %v", err)
 		}

--- a/src/redis.go
+++ b/src/redis.go
@@ -30,6 +30,8 @@ type argumentList struct {
 	RenamedCommands  sdkArgs.JSON `default:"" help:"Map of default redis commands to their renamed form, if rename-command config has been used in the redis server."`
 	ConfigInventory  bool         `default:"true" help:"Provides CONFIG inventory information. Set it to 'false' in environments where the Redis CONFIG command is prohibited (e.g. AWS ElastiCache)"`
 	ShowVersion      bool         `default:"false" help:"Print build information and exit"`
+	UseTLS           bool         `default:"false" help:"Use TLS when communicating with the Redis server."`
+	SkipTLSVerify    bool         `default:"false" help:"Disable server name verification when connecting over TLS"`
 }
 
 const (
@@ -60,7 +62,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	conn, err := newRedisCon(args.Hostname, args.Port, args.UnixSocketPath, args.Password)
+	conn, err := newRedisCon(args.Hostname, args.Port, args.UnixSocketPath, args.Password, args.UseTLS, args.SkipTLSVerify)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Later versions of Redis (I believe 6+) support TLS connections.  When this is enabled, the nri-redis integration no longer functions because it doesn't support TLS.  The library used by this integration (redigo) does support it.  This PR simply adds the necessary parameters to enable TLS if desired.