### PR TITLE
config samples in V4 format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ FROM newrelic/infrastructure:latest
 ENV NRIA_IS_FORWARD_ONLY true
 ENV NRIA_K8S_INTEGRATION true
 COPY --from=builder /go/src/github.com/newrelic/nri-redis/bin/nri-redis /nri-sidecar/newrelic-infra/newrelic-integrations/bin/nri-redis
-COPY --from=builder /go/src/github.com/newrelic/nri-redis/redis-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/redis-definition.yml
+COPY --from=builder /go/src/github.com/newrelic/nri-redis/legacy/redis-definition.yml /nri-sidecar/newrelic-infra/newrelic-integrations/redis-definition.yml
 
 USER 1000

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,6 @@ integration-test:
 install: compile
 	@echo "=== $(INTEGRATION) === [ install ]: installing bin/$(BINARY_NAME)..."
 	@sudo install -D --mode=755 --owner=root --strip $(ROOT)bin/$(BINARY_NAME) $(INTEGRATIONS_DIR)/bin/$(BINARY_NAME)
-	@sudo install -D --mode=644 --owner=root $(ROOT)$(INTEGRATION)-definition.yml $(INTEGRATIONS_DIR)/$(INTEGRATION)-definition.yml
 	@sudo install -D --mode=644 --owner=root $(ROOT)$(INTEGRATION)-config.yml.sample $(CONFIG_DIR)/$(INTEGRATION)-config.yml.sample
 
 # Include thematic Makefiles

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -55,7 +55,7 @@ nfpms:
         dst: "/usr/share/doc/nri-redis/README.md"
       - src: "LICENSE"
         dst: "/usr/share/doc/nri-redis/LICENSE"
-      - src: "redis-definition.yml"
+      - src: "legacy/redis-definition.yml"
         dst: "/var/db/newrelic-infra/newrelic-integrations/redis-definition.yml"
         type: config
 
@@ -77,7 +77,9 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
       - redis-config.yml.sample
-      - redis-definition.yml
+      - src: 'legacy/redis-definition.yml'
+        dst: .
+        strip_parent: true
     format: tar.gz
 
   - id: nri-win
@@ -86,7 +88,9 @@ archives:
     name_template: "{{ .ProjectName }}-{{ .Arch }}.{{ .Version }}_dirty"
     files:
       - redis-config.yml.sample
-      - redis-win-definition.yml
+      - src: 'legacy/redis-win-definition.yml'
+        dst: .
+        strip_parent: true
     format: zip
 
 # we use custom publisher for fixing archives and signing them

--- a/build/release.mk
+++ b/build/release.mk
@@ -1,5 +1,5 @@
 BUILD_DIR    := ./bin/
-GORELEASER_VERSION := v0.169.0
+GORELEASER_VERSION := v0.174.1
 GORELEASER_BIN ?= bin/goreleaser
 
 bin:

--- a/legacy/redis-definition.yml
+++ b/legacy/redis-definition.yml
@@ -1,5 +1,5 @@
 name: com.newrelic.redis
-description: Reports status and metrics for redis service
+description: Reports status and metrics for redis service. Legacy file kept for compatibility.
 protocol_version: 3
 os: linux
 

--- a/legacy/redis-win-definition.yml
+++ b/legacy/redis-win-definition.yml
@@ -1,5 +1,5 @@
 name: com.newrelic.redis
-description: Reports status and metrics for redis service
+description: Reports status and metrics for redis service. Legacy file kept for compatibility.
 protocol_version: 3
 os: windows
 

--- a/redis-config.yml.sample
+++ b/redis-config.yml.sample
@@ -1,9 +1,7 @@
-integration_name: com.newrelic.redis
-
-instances:
-  - name: redis-metrics
-    command: metrics
-    arguments:
+integrations:
+  - name: nri-redis
+    env:
+      metrics: true
       hostname: localhost
       port: 6379
       keys: '{"0":["<KEY_1>"],"1":["<KEY_2>"]}'
@@ -32,12 +30,12 @@ instances:
       # Skip TLS verification
       # tls_insecure_skip_verify: true
 
+    interval: 15
     labels:
       environment: production
-
-  - name: redis-inventory
-    command: inventory
-    arguments:
+  - name: nri-redis
+    env:
+      inventory: true
       hostname: localhost
       port: 6379
 
@@ -59,5 +57,7 @@ instances:
       #   rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
       # Users may want to set this config if Redis server is using 'rename-command', to ensure nri-redis functionality
       # renamed_commands: '{"CONFIG":"b840fc02d524045429941cc15f59e41cb7be6c52"}'
+    inventory_source: config/redis
+    interval: 60
     labels:
       environment: production


### PR DESCRIPTION
- Adapt config samples to V4 config
- Move deprecated definition files to legacy folder and adapted goreleaser