### PR TITLE
fix(argsValidation): remove strict args validation

### DIFF
--- a/src/redis.go
+++ b/src/redis.go
@@ -63,6 +63,9 @@ func main() {
 
 	var c conn
 	switch {
+	// Notice that we are not checking UseUnixSocket since it is not used to define how to connect, but merely the entity name.
+	// There are users having use_unix_socket=true and then connecting with hostname and port,
+	// or use_unix_socket=false and then connecting with the unix socket.
 	case args.UnixSocketPath != "":
 		c, err = newSocketRedisCon(args.UnixSocketPath, dialOptions...)
 		fatalIfErr(err)

--- a/src/redis.go
+++ b/src/redis.go
@@ -62,7 +62,7 @@ func main() {
 	dialOptions := standardDialOptions(args.Password)
 
 	var c conn
-	if args.UseUnixSocket && args.UnixSocketPath != "" {
+	if args.UnixSocketPath != "" {
 		c, err = newSocketRedisCon(args.UnixSocketPath, dialOptions...)
 		fatalIfErr(err)
 	} else if args.Hostname != "" && args.Port > 0 {

--- a/src/redis.go
+++ b/src/redis.go
@@ -62,10 +62,11 @@ func main() {
 	dialOptions := standardDialOptions(args.Password)
 
 	var c conn
-	if args.UnixSocketPath != "" {
+	switch {
+	case args.UnixSocketPath != "":
 		c, err = newSocketRedisCon(args.UnixSocketPath, dialOptions...)
 		fatalIfErr(err)
-	} else if args.Hostname != "" && args.Port > 0 {
+	case args.Hostname != "" && args.Port > 0:
 		if args.UseTLS {
 			tlsDialOptions := tlsDialOptions(args.UseTLS, args.TLSInsecureSkipVerify)
 			dialOptions = append(dialOptions, tlsDialOptions...)
@@ -73,7 +74,7 @@ func main() {
 		redisURL := net.JoinHostPort(args.Hostname, strconv.Itoa(args.Port))
 		c, err = newNetworkRedisCon(redisURL, dialOptions...)
 		fatalIfErr(err)
-	} else {
+	default:
 		log.Fatal(errorArgs)
 	}
 


### PR DESCRIPTION
Basically in a past PR I introduced a stricter validation of args without noticing that `use_unix_socket` was false in defaults, but true in the sample config. 
Therefore, I guess many users have `use_unix_socket` set to true even if they are not using such connection method. 
Since that was introduced only to shape the entity name is possible that users still have that set to `false`, but pupulating  `UnixSocketPath`

I am reintroducing the behaviour in 1.6.3
https://github.com/newrelic/nri-redis/blob/0e426a97438135950aa7c1e14136786b387ea71b/src/connection.go#L49