### PR TITLE
Fix Renamed Commands Value Receiver Func

### DIFF
--- a/src/connection.go
+++ b/src/connection.go
@@ -16,13 +16,15 @@ type conn interface {
 	setKeysType(string, []string, map[string]keyInfo) error
 	setKeysLength(string, []string, map[string]keyInfo) error
 	GetRawCustomKeys(map[string][]string) (map[string]map[string]keyInfo, error)
-	RenameCommands(map[string]string)
 	Close()
 }
 
 type redisConn struct {
-	c redis.Conn
+	c   redis.Conn
+	cfg redisConfig
+}
 
+type redisConfig struct {
 	// renamedCommands is the renamed-version of Redis commands used throughout nri-redis
 	// This is used to allow usage of 'renamed-command' in Redis server.
 	// Example Redis server config:
@@ -45,23 +47,23 @@ func (c configConnectionError) Error() string {
 	return "can't execute redis 'CONFIG' command: " + c.cause.Error()
 }
 
-func newSocketRedisCon(unixSocket string, options ...redis.DialOption) (conn, error) {
+func newSocketRedisCon(unixSocket string, cfg redisConfig, options ...redis.DialOption) (conn, error) {
 	c, err := redis.Dial("unix", unixSocket, options...)
 	if err != nil {
 		return nil, fmt.Errorf("connecting through Unix Socket: %w\", err", err)
 	}
 	log.Debug("Connected to Redis through Unix Socket %s", unixSocket)
-	return redisConn{c, nil}, nil
+	return redisConn{c, cfg}, nil
 }
 
-func newNetworkRedisCon(redisURL string, options ...redis.DialOption) (conn, error) {
+func newNetworkRedisCon(redisURL string, cfg redisConfig, options ...redis.DialOption) (conn, error) {
 	c, err := redis.Dial("tcp", redisURL, options...)
 	if err != nil {
 		return nil, fmt.Errorf("connecting through TCP: %w", err)
 	}
 	log.Debug("Connected to Redis through TCP %s", redisURL)
 
-	return redisConn{c, nil}, nil
+	return redisConn{c, cfg}, nil
 }
 
 func standardDialOptions(password string) []redis.DialOption {
@@ -98,11 +100,6 @@ func (r redisConn) GetConfig() (map[string]string, error) {
 		return nil, configConnectionError{cause: err}
 	}
 	return redis.StringMap(r.c.Receive())
-}
-
-// RenameCommands will populate internal renamedCommands mapping
-func (r redisConn) RenameCommands(renamedCommands map[string]string) {
-	r.renamedCommands = renamedCommands
 }
 
 func (r redisConn) Close() {
@@ -219,7 +216,7 @@ func (r redisConn) GetRawCustomKeys(databaseKeys map[string][]string) (map[strin
 // Supports:
 //   - Renamed version of 'command' if exists
 func (r redisConn) command(command string) string {
-	if renamedCommand, ok := r.renamedCommands[command]; ok {
+	if renamedCommand, ok := r.cfg.renamedCommands[command]; ok {
 		return renamedCommand
 	}
 	return command

--- a/src/connection_test.go
+++ b/src/connection_test.go
@@ -46,7 +46,9 @@ func Test_redisConn_command(t *testing.T) {
 	renamedCommandsTestCase["RENAMED-CONFIG"] = "NEW-RENAMED-CONFIG"
 	renamedCommandsTestCase["DISABLED-COMMAND"] = ""
 
-	c := redisConn{c: fakeConn{}, cfg: redisConfig{renamedCommands: renamedCommandsTestCase}}
+	c := redisConn{c: fakeConn{}}
+
+	c.RenameCommands(renamedCommandsTestCase)
 
 	type fields struct {
 		c redisConn

--- a/src/connection_test.go
+++ b/src/connection_test.go
@@ -46,7 +46,7 @@ func Test_redisConn_command(t *testing.T) {
 	renamedCommandsTestCase["RENAMED-CONFIG"] = "NEW-RENAMED-CONFIG"
 	renamedCommandsTestCase["DISABLED-COMMAND"] = ""
 
-	c := redisConn{c: fakeConn{}, renamedCommands: renamedCommandsTestCase}
+	c := redisConn{c: fakeConn{}, cfg: redisConfig{renamedCommands: renamedCommandsTestCase}}
 
 	type fields struct {
 		c redisConn

--- a/src/redis.go
+++ b/src/redis.go
@@ -59,16 +59,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	redisConfig := redisConfig{}
 	dialOptions := standardDialOptions(args.Password)
-
-	// Support using renamed form of redis commands, if 'renamed-command' config is used in Redis server
-	if args.RenamedCommands.Get() != nil {
-		renamedCommands, err := getRenamedCommands(args.RenamedCommands)
-		fatalIfErr(err)
-
-		redisConfig.renamedCommands = renamedCommands
-	}
 
 	var c conn
 	switch {
@@ -76,7 +67,7 @@ func main() {
 	// There are users having use_unix_socket=true and then connecting with hostname and port,
 	// or use_unix_socket=false and then connecting with the unix socket.
 	case args.UnixSocketPath != "":
-		c, err = newSocketRedisCon(args.UnixSocketPath, redisConfig, dialOptions...)
+		c, err = newSocketRedisCon(args.UnixSocketPath, dialOptions...)
 		fatalIfErr(err)
 	case args.Hostname != "" && args.Port > 0:
 		if args.UseTLS {
@@ -84,13 +75,21 @@ func main() {
 			dialOptions = append(dialOptions, tlsDialOptions...)
 		}
 		redisURL := net.JoinHostPort(args.Hostname, strconv.Itoa(args.Port))
-		c, err = newNetworkRedisCon(redisURL, redisConfig, dialOptions...)
+		c, err = newNetworkRedisCon(redisURL, dialOptions...)
 		fatalIfErr(err)
 	default:
 		log.Fatal(errorArgs)
 	}
 
 	defer c.Close()
+
+	// Support using renamed form of redis commands, if 'renamed-command' config is used in Redis server
+	if args.RenamedCommands.Get() != nil {
+		renamedCommands, err := getRenamedCommands(args.RenamedCommands)
+		fatalIfErr(err)
+
+		c.RenameCommands(renamedCommands)
+	}
 
 	info, err := c.GetInfo()
 	fatalIfErr(err)


### PR DESCRIPTION
Solution 1 for https://github.com/newrelic/nri-redis/pull/115#issuecomment-898908221

The redisConfig struct serves as non-dial related configuration for
redisConn