### PR TITLE
fix RenameCommands not having any effect

### DIFF
--- a/src/args_test.go
+++ b/src/args_test.go
@@ -121,7 +121,8 @@ func Test_getRenamedCommands(t *testing.T) {
 				*sdkArgs.NewJSON(map[string]interface{}{
 					"NON-RENAMED-COMMAND":    "NON-RENAMED-COMMAND",
 					"RENAMED-CONFIG":         "NEW-RENAMED-CONFIG",
-					"ANOTHER-RENAMED-CONFIG": "ANOTHER-RENAMED-CONFIG"},
+					"ANOTHER-RENAMED-CONFIG": "ANOTHER-RENAMED-CONFIG",
+				},
 				),
 			},
 			map[string]string{

--- a/src/connection.go
+++ b/src/connection.go
@@ -70,7 +70,8 @@ func standardDialOptions(username string, password string) []redis.DialOption {
 		redis.DialReadTimeout(defaultTimeout),
 		redis.DialWriteTimeout(defaultTimeout),
 		redis.DialUsername(username),
-		redis.DialPassword(password)}
+		redis.DialPassword(password),
+	}
 }
 
 func tlsDialOptions(useTLS bool, tlsInsecureSkipVerify bool) []redis.DialOption {
@@ -111,7 +112,6 @@ func (r redisConn) Close() {
 }
 
 func (r redisConn) setKeysType(db string, keys []string, info map[string]keyInfo) error {
-
 	_, err := r.c.Do(r.command("SELECT"), db)
 	if err != nil {
 		return fmt.Errorf("Cannot connect to db: %s, information for keys: %v will not be reported, got error: %v ", db, keys, err)
@@ -143,7 +143,6 @@ func (r redisConn) setKeysType(db string, keys []string, info map[string]keyInfo
 }
 
 func (r redisConn) setKeysLength(db string, keys []string, info map[string]keyInfo) error {
-
 	_, err := r.c.Do(r.command("SELECT"), db)
 	if err != nil {
 		return fmt.Errorf("Cannot connect to db: %s, information for keys: %v will not be reported, got error: %v ", db, keys, err)

--- a/src/connection.go
+++ b/src/connection.go
@@ -35,23 +35,23 @@ func (c configConnectionError) Error() string {
 	return "can't execute redis 'CONFIG' command: " + c.cause.Error()
 }
 
-func newSocketRedisCon(unixSocket string, options ...redis.DialOption) (redisConn, error) {
+func newSocketRedisCon(unixSocket string, options ...redis.DialOption) (*redisConn, error) {
 	c, err := redis.Dial("unix", unixSocket, options...)
 	if err != nil {
-		return redisConn{}, fmt.Errorf("connecting through Unix Socket: %w\", err", err)
+		return nil, fmt.Errorf("connecting through Unix Socket: %w\", err", err)
 	}
 	log.Debug("Connected to Redis through Unix Socket %s", unixSocket)
-	return redisConn{c, nil}, nil
+	return &redisConn{c, nil}, nil
 }
 
-func newNetworkRedisCon(redisURL string, options ...redis.DialOption) (redisConn, error) {
+func newNetworkRedisCon(redisURL string, options ...redis.DialOption) (*redisConn, error) {
 	c, err := redis.Dial("tcp", redisURL, options...)
 	if err != nil {
-		return redisConn{}, fmt.Errorf("connecting through TCP: %w", err)
+		return nil, fmt.Errorf("connecting through TCP: %w", err)
 	}
 	log.Debug("Connected to Redis through TCP %s", redisURL)
 
-	return redisConn{c, nil}, nil
+	return &redisConn{c, nil}, nil
 }
 
 func standardDialOptions(username string, password string) []redis.DialOption {

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -98,7 +98,6 @@ func populateMetrics(sample *metric.Set, metrics map[string]interface{}, definit
 			continue
 		}
 		err := sample.SetMetric(metricName, rawMetric, metricType)
-
 		if err != nil {
 			log.Warn("Error setting value: %s", err)
 			continue

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -2,17 +2,15 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/newrelic/infra-integrations-sdk/data/attribute"
 	"github.com/newrelic/infra-integrations-sdk/data/metric"
 	"github.com/newrelic/infra-integrations-sdk/persist"
 	"github.com/stretchr/testify/assert"
-
-	"io/ioutil"
-	"os"
-
-	"reflect"
 )
 
 var expectedRawInfoFromSample = map[string]interface{}{

--- a/src/redis.go
+++ b/src/redis.go
@@ -62,7 +62,7 @@ func main() {
 
 	dialOptions := standardDialOptions(args.Username, args.Password)
 
-	var c redisConn
+	var c *redisConn
 	switch {
 	// Notice that we are not checking UseUnixSocket since it is not used to define how to connect, but merely the entity name.
 	// There are users having use_unix_socket=true and then connecting with hostname and port,

--- a/src/redis.go
+++ b/src/redis.go
@@ -62,7 +62,7 @@ func main() {
 
 	dialOptions := standardDialOptions(args.Username, args.Password)
 
-	var c conn
+	var c redisConn
 	switch {
 	// Notice that we are not checking UseUnixSocket since it is not used to define how to connect, but merely the entity name.
 	// There are users having use_unix_socket=true and then connecting with hostname and port,


### PR DESCRIPTION
RenameCommands method now uses a pointer receiver. This fixed a bug which caused this setting to be ineffective (since commands were being remapped in a copy of the object, and therefore lost).

This change would have required all methods of the `conn` interface to have pointer receivers, which would have a slight performance penalty due to the double indirection performed. Instead of doing this, the conn interface has been just removed, since it wasn't actually used anywhere neither had more than one implementation.

---
Supersedes #127 