### PR TITLE
New Automatic Redis OHI Logging Template

### DIFF
--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -49,6 +49,8 @@ nfpms:
     contents:
       - src: "redis-config.yml.sample"
         dst: "/etc/newrelic-infra/integrations.d/redis-config.yml.sample"
+      - src: "redis-log.yml.example"
+        dst: "/etc/newrelic-infra/logging.d/redis-log.yml.example"
       - src: "CHANGELOG.md"
         dst: "/usr/share/doc/nri-redis/CHANGELOG.md"
       - src: "README.md"

--- a/redis-log.yml.example
+++ b/redis-log.yml.example
@@ -1,0 +1,12 @@
+###############################################################################
+# This sample file will forward redis error logs to NR once                   #
+#   it is renamed to redis-log.yml                                            #
+# On Linux systems no restart is needed after it is renamed                   #
+# Source: redis error log file                                                #
+# Available customization parameters: attributes, max_line_kb, pattern        #
+###############################################################################
+logs:
+  - name: "redislog"
+    file: /var/log/redis/redis-server.log
+    attributes:
+      logtype: redis


### PR DESCRIPTION
Initial commit for an automatic Redis OHI logging template file. Once renamed, Redis logs will automatically be sent to NR for user consumption. These logs will also automatically be parsed with our default parser.