### PR TITLE
feat(redis): add keyspace metrics support for dragonfly

### DIFF
--- a/src/metrics.go
+++ b/src/metrics.go
@@ -12,6 +12,12 @@ import (
 	"github.com/newrelic/infra-integrations-sdk/v3/log"
 )
 
+var (
+	keysRegexp    = regexp.MustCompile(`\bkeys=(\d+)`)
+	expiresRegexp = regexp.MustCompile(`\bexpires=(\d+)`)
+	avgTTLRegexp  = regexp.MustCompile(`\bavg_ttl=(-?\d+(?:\.\d+)?)`)
+)
+
 var metricsDefinition = map[string][]interface{}{
 	// Server
 	"software.uptimeMilliseconds": {secondsToMilliseconds("uptime_in_seconds"), metric.GAUGE},
@@ -176,18 +182,34 @@ func getRawMetrics(info string) (map[string]interface{}, map[string]map[string]i
 
 func parseKeyspaceMetrics(dbName string, keyspace string) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
-	re, err := regexp.Compile(`keys=(\d+),expires=(\d+),avg_ttl=(\d+\.*\d*)`)
-	if err != nil {
-		return nil, err
-	}
-	matches := re.FindStringSubmatch(keyspace)
-	if matches != nil {
-		m["keyspace"] = asValue(dbName)
-		m["keys"] = asValue(matches[1])
-		m["expires"] = asValue(matches[2])
-		m["avg_ttl"] = asValue(matches[3])
-	} else {
+
+	keysMatch := keysRegexp.FindStringSubmatch(keyspace)
+	expiresMatch := expiresRegexp.FindStringSubmatch(keyspace)
+	avgTTLMatch := avgTTLRegexp.FindStringSubmatch(keyspace)
+
+	if keysMatch == nil && expiresMatch == nil && avgTTLMatch == nil {
 		log.Warn("Keyspace metrics cannot be parsed for %s", dbName)
+		return m, nil
+	}
+
+	m["keyspace"] = asValue(dbName)
+
+	if keysMatch != nil {
+		m["keys"] = asValue(keysMatch[1])
+	} else {
+		log.Warn("keys metric cannot be parsed for %s", dbName)
+	}
+
+	if expiresMatch != nil {
+		m["expires"] = asValue(expiresMatch[1])
+	} else {
+		log.Warn("expires metric cannot be parsed for %s", dbName)
+	}
+
+	if avgTTLMatch != nil {
+		m["avg_ttl"] = asValue(avgTTLMatch[1])
+	} else {
+		log.Warn("avg_ttl metric cannot be parsed for %s", dbName)
 	}
 
 	return m, nil

--- a/src/metrics_test.go
+++ b/src/metrics_test.go
@@ -320,9 +320,50 @@ func TestParseKeyspaceMetrics(t *testing.T) {
 	}
 }
 
+func TestParseKeyspaceMetricsDragonflyNegativeAvgTTL(t *testing.T) {
+	dbName := "db0"
+	keyspace := "keys=35504609,expires=35504098,avg_ttl=-1"
+	m, err := parseKeyspaceMetrics(dbName, keyspace)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"keyspace": "db0",
+		"keys":     35504609,
+		"expires":  35504098,
+		"avg_ttl":  -1,
+	}, m)
+}
+
+func TestParseKeyspaceMetricsDragonflyExtraFields(t *testing.T) {
+	dbName := "db0"
+	keyspace := "keys=100,expires=50,key_reads=200,key_writes=150,key_deletes=10,avg_ttl=-30000"
+	m, err := parseKeyspaceMetrics(dbName, keyspace)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"keyspace": "db0",
+		"keys":     100,
+		"expires":  50,
+		"avg_ttl":  -30000,
+	}, m)
+}
+
+func TestParseKeyspaceMetricsMissingAvgTTL(t *testing.T) {
+	dbName := "db0"
+	keyspace := "keys=5,expires=2"
+	m, err := parseKeyspaceMetrics(dbName, keyspace)
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"keyspace": "db0",
+		"keys":     5,
+		"expires":  2,
+	}, m)
+}
+
 func TestParseKeyspaceMetricsNoMatch(t *testing.T) {
 	dbName := "db0"
-	keyspace := "db0:keys=3,expires=1,"
+	keyspace := "invalid_keyspace_data"
 	metrics, err := parseKeyspaceMetrics(dbName, keyspace)
 	expectedLength := 0
 	expectedMetrics := make(map[string]interface{})
@@ -336,6 +377,18 @@ func TestParseKeyspaceMetricsNoMatch(t *testing.T) {
 	if !reflect.DeepEqual(metrics, expectedMetrics) {
 		t.Error()
 	}
+}
+
+func TestParseKeyspaceMetricsPartialMatch(t *testing.T) {
+	dbName := "db0"
+	keyspace := "expires=5,avg_ttl=1000"
+	m, err := parseKeyspaceMetrics(dbName, keyspace)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"keyspace": "db0",
+		"expires":  5,
+		"avg_ttl":  1000,
+	}, m)
 }
 
 func TestPopulateCustomKeysMetric(t *testing.T) {

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -49,6 +49,30 @@ services:
       - nri-redis
     entrypoint: ["redis-server", "/usr/local/etc/redis/redis.conf"]
 
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:latest
+    hostname: dragonfly
+    ports:
+      - "6382:6379"
+    restart: always
+    ulimits:
+      memlock: -1
+    entrypoint: /bin/sh
+    command: >
+      -c " \
+        dragonfly --logtostderr & \
+        pid=\"$$!\" \
+        until redis-cli ping > /dev/null 2>&1; do \
+          sleep 1; \
+        done; \
+        sh /init-dragonfly.sh; \
+        wait \"$$pid\" \
+      "
+    volumes:
+      - ./init-dragonfly.sh:/init-dragonfly.sh
+    links:
+      - nri-redis
+
   nri-redis:
     container_name: integration_nri-redis_1
     build:

--- a/tests/integration/init-dragonfly.sh
+++ b/tests/integration/init-dragonfly.sh
@@ -1,0 +1,3 @@
+redis-cli -n 0 LPUSH list_df0 "item1" "item2" "item3"
+
+echo "Finished initializing Dragonfly data."

--- a/tests/integration/json-schema-files/dragonfly-schema-metrics.json
+++ b/tests/integration/json-schema-files/dragonfly-schema-metrics.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "",
+  "properties": {
+    "integration_version": {
+      "minLength": 1,
+      "pattern": "^\\d.\\d.\\d$",
+      "type": "string"
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "events": {
+            "items": {
+              "properties": {},
+              "required": []
+            },
+            "type": "array"
+          },
+          "inventory": {
+            "properties": {},
+            "required": [],
+            "type": "object"
+          },
+          "metrics": {
+            "items": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "cluster.connectedSlaves": {
+                      "type": "number"
+                    },
+                    "cluster.role": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "db.evictedKeysPerSecond": {
+                      "type": "number"
+                    },
+                    "db.expiredKeysPerSecond": {
+                      "type": "number"
+                    },
+                    "db.keyspaceHitsPerSecond": {
+                      "type": "number"
+                    },
+                    "db.keyspaceMissesPerSecond": {
+                      "type": "number"
+                    },
+                    "event_type": {
+                      "minLength": 1,
+                      "pattern": "^RedisSample$",
+                      "type": "string"
+                    },
+                    "net.blockedClients": {
+                      "type": "number"
+                    },
+                    "net.commandsProcessedPerSecond": {
+                      "type": "number"
+                    },
+                    "net.connectedClients": {
+                      "type": "number"
+                    },
+                    "net.connectionsReceivedPerSecond": {
+                      "type": "number"
+                    },
+                    "net.inputBytesPerSecond": {
+                      "type": "number"
+                    },
+                    "net.outputBytesPerSecond": {
+                      "type": "number"
+                    },
+                    "net.rejectedConnectionsPerSecond": {
+                      "type": "number"
+                    },
+                    "port": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "software.uptimeMilliseconds": {
+                      "type": "number"
+                    },
+                    "software.version": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "system.maxmemoryBytes": {
+                      "type": "number"
+                    },
+                    "system.usedCpuSysChildrenMilliseconds": {
+                      "type": "number"
+                    },
+                    "system.usedCpuSysMilliseconds": {
+                      "type": "number"
+                    },
+                    "system.usedCpuUserChildrenMilliseconds": {
+                      "type": "number"
+                    },
+                    "system.usedCpuUserMilliseconds": {
+                      "type": "number"
+                    },
+                    "system.usedMemoryBytes": {
+                      "type": "number"
+                    },
+                    "system.usedMemoryLuaBytes": {
+                      "type": "number"
+                    },
+                    "system.usedMemoryPeakBytes": {
+                      "type": "number"
+                    },
+                    "system.usedMemoryRssBytes": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "cluster.connectedSlaves",
+                    "cluster.role",
+                    "db.evictedKeysPerSecond",
+                    "db.expiredKeysPerSecond",
+                    "db.keyspaceHitsPerSecond",
+                    "db.keyspaceMissesPerSecond",
+                    "event_type",
+                    "net.blockedClients",
+                    "net.commandsProcessedPerSecond",
+                    "net.connectedClients",
+                    "net.connectionsReceivedPerSecond",
+                    "net.inputBytesPerSecond",
+                    "net.outputBytesPerSecond",
+                    "net.rejectedConnectionsPerSecond",
+                    "port",
+                    "software.uptimeMilliseconds",
+                    "software.version",
+                    "system.maxmemoryBytes",
+                    "system.usedCpuSysChildrenMilliseconds",
+                    "system.usedCpuSysMilliseconds",
+                    "system.usedCpuUserChildrenMilliseconds",
+                    "system.usedCpuUserMilliseconds",
+                    "system.usedMemoryBytes",
+                    "system.usedMemoryLuaBytes",
+                    "system.usedMemoryPeakBytes",
+                    "system.usedMemoryRssBytes"
+                  ]
+                },
+                {
+                  "properties": {
+                    "db.avgTtlMilliseconds": {
+                      "type": "number"
+                    },
+                    "db.expires": {
+                      "type": "number"
+                    },
+                    "db.keys": {
+                      "type": "number"
+                    },
+                    "db.keyspace": {
+                      "type": "string"
+                    },
+                    "event_type": {
+                      "pattern": "^RedisKeyspaceSample$",
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "db.avgTtlMilliseconds",
+                    "db.expires",
+                    "db.keys",
+                    "db.keyspace",
+                    "event_type",
+                    "port"
+                  ]
+                }
+              ]
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "metrics",
+          "inventory",
+          "events"
+        ]
+      }
+    },
+    "name": {
+      "minLength": 1,
+      "pattern": "^com.newrelic.redis$",
+      "type": "string"
+    },
+    "protocol_version": {
+      "minLength": 1,
+      "pattern": "^3$",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "protocol_version",
+    "integration_version",
+    "data"
+  ],
+  "type": "object"
+}

--- a/tests/integration/redis_test.go
+++ b/tests/integration/redis_test.go
@@ -155,6 +155,23 @@ func TestRedisIntegration_OnlyInventory(t *testing.T) {
 	require.NotZerof(t, len(inventory), "inventory should include CONFIG data. Was %#v", inventory)
 }
 
+func TestDragonflyIntegration(t *testing.T) {
+	testName := t.Name()
+
+	envVars := []string{
+		fmt.Sprintf("NRIA_CACHE_PATH=/tmp/%v.json", testName),
+		"CONFIG_INVENTORY=false",
+	}
+	stdout, stderr := runIntegration(t, "dragonfly", defaultPort, false, "", "", envVars...)
+
+	schemaPath := filepath.Join("json-schema-files", "dragonfly-schema-metrics.json")
+
+	err := jsonschema.Validate(schemaPath, stdout)
+
+	assert.NoError(t, err, "The output of Dragonfly integration doesn't have expected format")
+	assert.NotNil(t, stderr, "unexpected stderr")
+}
+
 func TestRedisIntegration_SkipConfig(t *testing.T) {
 	testName := t.Name()
 


### PR DESCRIPTION
### Problem                                                                                                                                                        
                                                                                                                                                               
Dragonfly returns `avg_ttl=-1` in INFO keyspace output. The existing regex `keys=(\d+),expires=(\d+),avg_ttl=(\d+\.*\d*)` failed to match negative values, silently dropping all `RedisKeyspaceSample` events for Dragonfly databases. It also required fields to appear in a fixed order, making it fragile across `Redis-compatible` implementations. 

```sh
# redis-cli INFO keyspace
# Keyspace
db0:keys=1,expires=0,hits=0,misses=0,hit_ratio=0.00,avg_ttl=-1
```                                                                                                                                             
                                                                                                                                                               
### Changes in this PR                                                                                                                                                            
   
Replaced the single monolithic regex with 3 independent package-level compiled patterns that match each field separately, support negative integers in `avg_ttl`, and are order-independent. Missing fields are omitted from the output with a per-field warning rather than discarding the entire sample. Added unit tests covering negative `avg_ttl`, extra fields, partial matches, and missing fields, along with a Dragonfly-specific integration test and JSON schema reflecting the metrics Dragonfly actually emits. 

### Testing details
<details><summary>Details</summary>
<p>

```sh
./nri-redis --hostname dragonfly --port 6379
[WARN
] Can't find raw metrics in results for [net.clientBiggestInputBufBytes db.rdbLastSaveTime db.rdbLastBgsaveStatus net.pubsubChannels db.aofLastBgrewriteStatus system.memFragmentationRatio db.aofLastRewriteTimeMiliseconds db.aofLastWriteStatus db.syncPartialErr net.pubsubPatterns db.rdbChangesSinceLastSave system.totalSystemMemoryBytes db.syncFull db.latestForkMilliseconds db.rdbLastBgsaveTimeMilliseconds db.syncPartialOk db.rdbBgsaveInProgress net.clientLongestOutputList
]
{
    "name": "com.newrelic.redis",
    "protocol_version": "3",
    "integration_version": "0.0.0",
    "data": [
        {
            "metrics": [
                {
                    "cluster.connectedSlaves": 0,
                    "cluster.role": "master",
                    "db.evictedKeysPerSecond": 0,
                    "db.expiredKeysPerSecond": 0,
                    "db.keyspaceHitsPerSecond": 0,
                    "db.keyspaceMissesPerSecond": 0,
                    "event_type": "RedisSample",
                    "net.blockedClients": 0,
                    "net.commandsProcessedPerSecond": 0,
                    "net.connectedClients": 1,
                    "net.connectionsReceivedPerSecond": 0,
                    "net.inputBytesPerSecond": 0,
                    "net.outputBytesPerSecond": 0,
                    "net.rejectedConnectionsPerSecond": 0,
                    "port": "6379",
                    "software.uptimeMilliseconds": 423000,
                    "software.version": "7.4.0",
                    "system.maxmemoryBytes": 17091985408,
                    "system.usedCpuSysChildrenMilliseconds": 0,
                    "system.usedCpuSysMilliseconds": 3132,
                    "system.usedCpuUserChildrenMilliseconds": 0,
                    "system.usedCpuUserMilliseconds": 3210,
                    "system.usedMemoryBytes": 2261600,
                    "system.usedMemoryLuaBytes": 0,
                    "system.usedMemoryPeakBytes": 2261600,
                    "system.usedMemoryRssBytes": 85213184
                },
                {
                    "db.avgTtlMilliseconds": -1,
                    "db.expires": 0,
                    "db.keys": 1,
                    "db.keyspace": "db0",
                    "event_type": "RedisKeyspaceSample",
                    "port": "6379"
                }
            ],
            "inventory": {
                "MAXSEARCHRESULTS": {
                    "value": "1000000"
                },
                "aclfile": {
                    "value": ""
                },
                "acllog_max_len": {
                    "value": "32"
                },
                "always_flush_pipeline": {
                    "value": "false"
                },
                "background_debug_jobs": {
                    "value": "false"
                },
                "background_snapshotting": {
                    "value": "false"
                },
                "config-file": {
                    "value": ""
                },
                "dbfilename": {
                    "value": "dump-{timestamp}"
                },
                "dbnum": {
                    "value": "16"
                },
                "dir": {
                    "value": ""
                },
                "enable_heartbeat_eviction": {
                    "value": "true"
                },
                "enable_heartbeat_rss_eviction": {
                    "value": "true"
                },
                "executable": {
                    "value": "dragonfly"
                },
                "log_squash_info_threshold_usec": {
                    "value": "2147483648"
                },
                "lua_float_as_int_shas": {
                    "value": ""
                },
                "lua_mem_gc_threshold": {
                    "value": "10000000"
                },
                "lua_undeclared_keys_shas": {
                    "value": ""
                },
                "managed_service_info": {
                    "value": "false"
                },
                "masterauth": {
                    "value": "(omitted value)"
                },
                "masteruser": {
                    "value": ""
                },
                "max_busy_read_usec": {
                    "value": "200"
                },
                "max_busy_squash_usec": {
                    "value": "1000"
                },
                "max_eviction_per_heartbeat": {
                    "value": "100"
                },
                "max_segment_to_consider": {
                    "value": "4"
                },
                "max_squashed_cmd_num": {
                    "value": "100"
                },
                "maxclients": {
                    "value": "64000"
                },
                "maxmemory": {
                    "value": "17091985408"
                },
                "migration_finalization_timeout_ms": {
                    "value": "30000"
                },
                "notify_keyspace_events": {
                    "value": ""
                },
                "pipeline_buffer_limit": {
                    "value": "134217728"
                },
                "pipeline_queue_limit": {
                    "value": "10000"
                },
                "pipeline_squash": {
                    "value": "1"
                },
                "pipeline_squash_limit": {
                    "value": "1073741824"
                },
                "pipeline_wait_batch_usec": {
                    "value": "0"
                },
                "redis_version": {
                    "value": "7.4.0"
                },
                "replica_partial_sync": {
                    "value": "true"
                },
                "replica_priority": {
                    "value": "100"
                },
                "replication_timeout": {
                    "value": "30000"
                },
                "requirepass": {
                    "value": "(omitted value)"
                },
                "rss_oom_deny_ratio": {
                    "value": "1.25"
                },
                "scheduler_background_budget": {
                    "value": "50000"
                },
                "scheduler_background_sleep_prob": {
                    "value": "50"
                },
                "scheduler_background_warrant": {
                    "value": "5"
                },
                "search.query-string-bytes": {
                    "value": "10240"
                },
                "send_timeout": {
                    "value": "0"
                },
                "serialization_max_chunk_size": {
                    "value": "65536"
                },
                "shard_thread_busy_polling_usec": {
                    "value": "0"
                },
                "slot_migration_throttle_us": {
                    "value": "0"
                },
                "slowlog_log_slower_than": {
                    "value": "10000"
                },
                "slowlog_max_len": {
                    "value": "20"
                },
                "snapshot_cron": {
                    "value": ""
                },
                "squash_stats_latency_lower_limit": {
                    "value": "0"
                },
                "table_growth_margin": {
                    "value": "0.4"
                },
                "tcp_keepalive": {
                    "value": "300"
                },
                "tiered_experimental_cooling": {
                    "value": "true"
                },
                "tiered_experimental_hash_support": {
                    "value": "false"
                },
                "tiered_experimental_list_support": {
                    "value": "false"
                },
                "tiered_min_value_size": {
                    "value": "64"
                },
                "tiered_offload_threshold": {
                    "value": "0.5"
                },
                "tiered_storage_write_depth": {
                    "value": "200"
                },
                "tiered_upload_threshold": {
                    "value": "0.1"
                },
                "timeout": {
                    "value": "0"
                },
                "tls": {
                    "value": "false"
                },
                "tls_ca_cert_dir": {
                    "value": ""
                },
                "tls_ca_cert_file": {
                    "value": ""
                },
                "tls_cert_file": {
                    "value": ""
                },
                "tls_key_file": {
                    "value": ""
                }
            },
            "events": []
        }
    ]
}
```

</p>
</details> 