### PR TITLE
Add pipeline for publishing OHI to New Relic Control catalog

### DIFF
--- a/.fleetControl/agentControl/linux.yml
+++ b/.fleetControl/agentControl/linux.yml
@@ -1,0 +1,61 @@
+namespace: newrelic
+name: com.newrelic.integration_redis
+version: 0.1.0
+parent_agent: newrelic/com.newrelic.infrastructure:0.1.0
+variables:
+  linux:
+    config_integration:
+      description: "Newrelic infra configuration"
+      type: yaml
+      required: false
+      default: ""
+    oci:
+      registry:
+        description: "Package registry url"
+        type: string
+        required: false
+        default: docker.io
+        variants:
+          ac_config_field: "oci_registry_urls"
+          values: [ "docker.io" ]
+      repository:
+        description: "Package repository name"
+        type: string
+        required: false
+        default: newrelic/nri-redis-artifacts
+        variants:
+          ac_config_field: "oci_repository_urls"
+          values: [ "newrelic/nri-redis-artifacts" ]
+    version:
+      description: "Agent version"
+      type: string
+      required: true
+deployment:
+  linux:
+    # Redis integration doesn't run as a separate process; it's called by the infrastructure agent
+    packages:
+      nri-redis:
+        download:
+          oci:
+            registry: ${nr-var:oci.registry}
+            repository: ${nr-var:oci.repository}
+            version: ${nr-var:version}
+            public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
+        post_install:
+          - type: copy
+            source: ${nr-sub:packages.nri-redis.dir}/nri-redis
+            destination: ${nr-parent:filesystem_agent_dir}/integrations/nri-redis
+            create_parent_dirs: true
+          - type: copy
+            source: ${nr-sub:filesystem_agent_dir}/config/integration_redis.yaml
+            destination: ${nr-parent:filesystem_agent_dir}/integrations.d/integration_redis.yaml
+            create_parent_dirs: true
+    version:
+      path: ${nr-sub:packages.nri-redis.dir}/nri-redis
+      args:
+        - --version
+      regex: \d+\.\d+\.\d+
+    filesystem:
+      config:
+        integration_redis.yaml: |
+          ${nr-var:config_integration}

--- a/.fleetControl/agentControl/linux.yml
+++ b/.fleetControl/agentControl/linux.yml
@@ -1,61 +1,46 @@
 namespace: newrelic
-name: com.newrelic.integration_redis
+name: com.newrelic.infrastructure.nri_redis
 version: 0.1.0
-parent_agent: newrelic/com.newrelic.infrastructure:0.1.0
+platform: host
+operating_system: linux
+protocol_version: "1.0"
 variables:
-  linux:
-    config_integration:
-      description: "Newrelic infra configuration"
-      type: yaml
-      required: false
-      default: ""
-    oci:
-      registry:
-        description: "Package registry url"
-        type: string
-        required: false
-        default: docker.io
-        variants:
-          ac_config_field: "oci_registry_urls"
-          values: [ "docker.io" ]
-      repository:
-        description: "Package repository name"
-        type: string
-        required: false
-        default: newrelic/nri-redis-artifacts
-        variants:
-          ac_config_field: "oci_repository_urls"
-          values: [ "newrelic/nri-redis-artifacts" ]
-    version:
-      description: "Agent version"
+  config:
+    description: "nri-redis integration YAML consumed by the infra-agent"
+    type: yaml
+    required: true
+  version:
+    description: "Agent version"
+    type: string
+    required: true
+  oci:
+    repository:
+      description: "OCI repository name for nri-redis"
       type: string
-      required: true
+      required: false
+      default: newrelic/nri-redis-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/nri-redis-artifacts" ]
 deployment:
-  linux:
-    # Redis integration doesn't run as a separate process; it's called by the infrastructure agent
-    packages:
-      nri-redis:
-        download:
-          oci:
-            registry: ${nr-var:oci.registry}
-            repository: ${nr-var:oci.repository}
-            version: ${nr-var:version}
-            public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
-        post_install:
-          - type: copy
-            source: ${nr-sub:packages.nri-redis.dir}/nri-redis
-            destination: ${nr-parent:filesystem_agent_dir}/integrations/nri-redis
-            create_parent_dirs: true
-          - type: copy
-            source: ${nr-sub:filesystem_agent_dir}/config/integration_redis.yaml
-            destination: ${nr-parent:filesystem_agent_dir}/integrations.d/integration_redis.yaml
-            create_parent_dirs: true
-    version:
-      path: ${nr-sub:packages.nri-redis.dir}/nri-redis
-      args:
-        - --version
-      regex: \d+\.\d+\.\d+
-    filesystem:
-      config:
-        integration_redis.yaml: |
-          ${nr-var:config_integration}
+  packages:
+    nri-redis:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nri-redis/jwks.json
+  shared_filesystem:
+    infra-agent-ohi-configs:
+      kind: dir
+      entries:
+        nri-redis.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-redis:
+          kind: file
+          copy_from_file: ${nr-sub:packages.nri-redis.dir}/nri-redis

--- a/.fleetControl/agentControl/windows.yml
+++ b/.fleetControl/agentControl/windows.yml
@@ -1,61 +1,46 @@
 namespace: newrelic
-name: com.newrelic.integration_redis
+name: com.newrelic.infrastructure.nri_redis
 version: 0.1.0
-parent_agent: newrelic/com.newrelic.infrastructure:0.1.0
+platform: host
+operating_system: windows
+protocol_version: "1.0"
 variables:
-  windows:
-    config_integration:
-      description: "Newrelic infra configuration"
-      type: yaml
-      required: false
-      default: ""
-    oci:
-      registry:
-        description: "Package registry url"
-        type: string
-        required: false
-        default: docker.io
-        variants:
-          ac_config_field: "oci_registry_urls"
-          values: [ "docker.io" ]
-      repository:
-        description: "Package repository name"
-        type: string
-        required: false
-        default: newrelic/nri-redis-artifacts
-        variants:
-          ac_config_field: "oci_repository_urls"
-          values: [ "newrelic/nri-redis-artifacts" ]
-    version:
-      description: "Agent version"
+  config:
+    description: "nri-redis integration YAML consumed by the infra-agent"
+    type: yaml
+    required: true
+  version:
+    description: "Agent version"
+    type: string
+    required: true
+  oci:
+    repository:
+      description: "OCI repository name for nri-redis"
       type: string
-      required: true
+      required: false
+      default: newrelic/nri-redis-artifacts
+      variants:
+        ac_config_field: "oci_repository_urls"
+        values: [ "newrelic/nri-redis-artifacts" ]
 deployment:
-  windows:
-    # Redis integration doesn't run as a separate process; it's called by the infrastructure agent
-    packages:
-      nri-redis:
-        download:
-          oci:
-            registry: ${nr-var:oci.registry}
-            repository: ${nr-var:oci.repository}
-            version: ${nr-var:version}
-            public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
-        post_install:
-          - type: copy
-            source: ${nr-sub:packages.nri-redis.dir}/nri-redis.exe
-            destination: ${nr-parent:filesystem_agent_dir}/integrations/nri-redis.exe
-            create_parent_dirs: true
-          - type: copy
-            source: ${nr-sub:filesystem_agent_dir}/config/integration_redis.yaml
-            destination: ${nr-parent:filesystem_agent_dir}/integrations.d/integration_redis.yaml
-            create_parent_dirs: true
-    version:
-      path: ${nr-sub:packages.nri-redis.dir}\\nri-redis.exe
-      args:
-        - --version
-      regex: \d+\.\d+\.\d+
-    filesystem:
-      config:
-        integration_redis.yaml: |
-          ${nr-var:config_integration}
+  packages:
+    nri-redis:
+      download:
+        oci:
+          repository: ${nr-var:oci.repository}
+          version: ${nr-var:version}
+          public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nri-redis/jwks.json
+  shared_filesystem:
+    infra-agent-ohi-configs:
+      kind: dir
+      entries:
+        nri-redis.yaml:
+          kind: file
+          text: |
+            ${nr-var:config}
+    infra-agent-ohi-binaries:
+      kind: dir
+      entries:
+        nri-redis.exe:
+          kind: file
+          copy_from_file: ${nr-sub:packages.nri-redis.dir}\\nri-redis.exe

--- a/.fleetControl/agentControl/windows.yml
+++ b/.fleetControl/agentControl/windows.yml
@@ -1,0 +1,61 @@
+namespace: newrelic
+name: com.newrelic.integration_redis
+version: 0.1.0
+parent_agent: newrelic/com.newrelic.infrastructure:0.1.0
+variables:
+  windows:
+    config_integration:
+      description: "Newrelic infra configuration"
+      type: yaml
+      required: false
+      default: ""
+    oci:
+      registry:
+        description: "Package registry url"
+        type: string
+        required: false
+        default: docker.io
+        variants:
+          ac_config_field: "oci_registry_urls"
+          values: [ "docker.io" ]
+      repository:
+        description: "Package repository name"
+        type: string
+        required: false
+        default: newrelic/nri-redis-artifacts
+        variants:
+          ac_config_field: "oci_repository_urls"
+          values: [ "newrelic/nri-redis-artifacts" ]
+    version:
+      description: "Agent version"
+      type: string
+      required: true
+deployment:
+  windows:
+    # Redis integration doesn't run as a separate process; it's called by the infrastructure agent
+    packages:
+      nri-redis:
+        download:
+          oci:
+            registry: ${nr-var:oci.registry}
+            repository: ${nr-var:oci.repository}
+            version: ${nr-var:version}
+            public_key_url: https://publickeys.newrelic.com/g/agent-control-oci/global/nrinfraagent/jwks.json
+        post_install:
+          - type: copy
+            source: ${nr-sub:packages.nri-redis.dir}/nri-redis.exe
+            destination: ${nr-parent:filesystem_agent_dir}/integrations/nri-redis.exe
+            create_parent_dirs: true
+          - type: copy
+            source: ${nr-sub:filesystem_agent_dir}/config/integration_redis.yaml
+            destination: ${nr-parent:filesystem_agent_dir}/integrations.d/integration_redis.yaml
+            create_parent_dirs: true
+    version:
+      path: ${nr-sub:packages.nri-redis.dir}\\nri-redis.exe
+      args:
+        - --version
+      regex: \d+\.\d+\.\d+
+    filesystem:
+      config:
+        integration_redis.yaml: |
+          ${nr-var:config_integration}

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,0 +1,11 @@
+agentControlDefinitions:
+  - platform: HOST
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.0.0
+    content: ./agentControl/windows.yml
+    operatingSystem: WINDOWS
+  - platform: HOST
+    supportFromAgent: 1.17.0
+    supportFromAgentControl: 1.0.0
+    content: ./agentControl/linux.yml
+    operatingSystem: LINUX

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,11 +1,11 @@
 agentControlDefinitions:
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.17.0
+    supportFromAgentControl: 1.19.0
     content: ./agentControl/windows.yml
     operatingSystem: WINDOWS
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.17.0
+    supportFromAgentControl: 1.19.0
     content: ./agentControl/linux.yml
     operatingSystem: LINUX

--- a/.fleetControl/agentControlDefinitions.yml
+++ b/.fleetControl/agentControlDefinitions.yml
@@ -1,11 +1,11 @@
 agentControlDefinitions:
   - platform: HOST
     supportFromAgent: 1.0.0
-    supportFromAgentControl: 1.0.0
+    supportFromAgentControl: 1.17.0
     content: ./agentControl/windows.yml
     operatingSystem: WINDOWS
   - platform: HOST
-    supportFromAgent: 1.17.0
-    supportFromAgentControl: 1.0.0
+    supportFromAgent: 1.0.0
+    supportFromAgentControl: 1.17.0
     content: ./agentControl/linux.yml
     operatingSystem: LINUX

--- a/.fleetControl/agentDefinition.yml
+++ b/.fleetControl/agentDefinition.yml
@@ -2,5 +2,14 @@ bindings:
   - type: REQUIRES
     targetType: AGENT
     target: NRInfra
+    platform: HOST
+    operatingSystem: LINUX
+    versions:
+      - ">1.71.0"
+  - type: REQUIRES
+    targetType: AGENT
+    target: NRInfra
+    platform: HOST
+    operatingSystem: WINDOWS
     versions:
       - ">1.71.0"

--- a/.fleetControl/agentDefinition.yml
+++ b/.fleetControl/agentDefinition.yml
@@ -1,0 +1,6 @@
+bindings:
+  - type: REQUIRES
+    targetType: AGENT
+    target: NRInfra
+    versions:
+      - ">1.71.0"

--- a/.fleetControl/configurationDefinitions.yml
+++ b/.fleetControl/configurationDefinitions.yml
@@ -1,0 +1,13 @@
+configurationDefinitions:
+  - platform: HOST
+    description: redis integration configuration
+    type: agent-config
+    version: 1.0.0
+    format: yml
+    operatingSystem: LINUX
+  - platform: HOST
+    description: redis integration configuration
+    type: agent-config
+    version: 1.0.0
+    format: yml
+    operatingSystem: WINDOWS

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -29,6 +29,4 @@ jobs:
           {"name":"linux-arm64","os":"linux","arch":"arm64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_arm64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-redis"]},
           {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-redis-amd64.{version}.zip","source_format":"zip","keep_files":["New Relic/newrelic-infra/newrelic-integrations/bin/nri-redis.exe"]}
         ]
-      source_repo: "newrelic/nri-redis"
-      metadata_git_ref: "master"
     secrets: inherit

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -16,14 +16,13 @@ permissions:
 
 jobs:
   oci-publish:
-    uses: jcoscollanr/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@main
-    # uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
     with:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
       agent_type: NRIRedis
       display_name: "New Relic Redis Integration"
       monitoring_type: ""
-      oci_registry: "docker.io/jcoscolla75954/nri-redis"
+      oci_registry: "docker.io/newrelic/nri-redis-artifacts"
       artifacts: |
         [
           {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-redis"]},

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -26,9 +26,9 @@ jobs:
       oci_registry: "docker.io/jcoscolla75954/nri-redis"
       artifacts: |
         [
-          {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["nri-redis"]},
-          {"name":"linux-arm64","os":"linux","arch":"arm64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_arm64.tar.gz","source_format":"tar.gz","keep_files":["nri-redis"]},
-          {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-redis-amd64.{version}.zip","source_format":"zip","keep_files":["nri-redis.exe"]}
+          {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-redis"]},
+          {"name":"linux-arm64","os":"linux","arch":"arm64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_arm64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-redis"]},
+          {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-redis-amd64.{version}.zip","source_format":"zip","keep_files":["New Relic/newrelic-infra/newrelic-integrations/bin/nri-redis.exe"]}
         ]
       source_repo: "newrelic/nri-redis"
       metadata_git_ref: "master"

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -22,7 +22,7 @@ jobs:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
       agent_type: NRIRedis
       display_name: "New Relic Redis Integration"
-      monitoring_type: INFRA
+      monitoring_type: ""
       oci_registry: "docker.io/jcoscolla75954/nri-redis"
       artifacts: |
         [

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -1,0 +1,35 @@
+name: Publish agent to catalog
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to process (e.g., v1.15.1)'
+        required: true
+        type: string
+  release:
+    types:
+      - released
+
+permissions:
+  contents: read
+
+jobs:
+  oci-publish:
+    uses: jcoscollanr/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@main
+    # uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
+    with:
+      tag: ${{ github.event.release.tag_name || inputs.tag }}
+      agent_type: NRIRedis
+      display_name: "New Relic Redis Integration"
+      monitoring_type: INFRA
+      oci_registry: "docker.io/jcoscolla75954/nri-redis"
+      artifacts: |
+        [
+          {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["nri-redis"]},
+          {"name":"linux-arm64","os":"linux","arch":"arm64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_arm64.tar.gz","source_format":"tar.gz","keep_files":["nri-redis"]},
+          {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-redis-amd64.{version}.zip","source_format":"zip","keep_files":["nri-redis.exe"]}
+        ]
+      source_repo: "newrelic/nri-redis"
+      metadata_git_ref: "master"
+    secrets: inherit

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -16,13 +16,14 @@ permissions:
 
 jobs:
   oci-publish:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@main
+    uses: jcoscollanr/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@main
+    # uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
     with:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
       agent_type: NRIRedis
       display_name: "New Relic Redis Integration"
       monitoring_type: ""
-      oci_registry: "docker.io/newrelic/nri-redis-artifacts"
+      oci_registry: "docker.io/jcoscolla75954/nri-redis"
       artifacts: |
         [
           {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-redis"]},
@@ -30,4 +31,5 @@ jobs:
           {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-redis-amd64.{version}.zip","source_format":"zip","keep_files":["New Relic/newrelic-infra/newrelic-integrations/bin/nri-redis.exe"]}
         ]
       source_repo: "newrelic/nri-redis"
+      metadata_git_ref: "master"
     secrets: inherit

--- a/.github/workflows/on_release_agent_control.yaml
+++ b/.github/workflows/on_release_agent_control.yaml
@@ -16,14 +16,13 @@ permissions:
 
 jobs:
   oci-publish:
-    uses: jcoscollanr/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@main
-    # uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_agent_control_release.yaml@main
     with:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
       agent_type: NRIRedis
       display_name: "New Relic Redis Integration"
       monitoring_type: ""
-      oci_registry: "docker.io/jcoscolla75954/nri-redis"
+      oci_registry: "docker.io/newrelic/nri-redis-artifacts"
       artifacts: |
         [
           {"name":"linux-amd64","os":"linux","arch":"amd64","format":"tar+gzip","source_asset":"nri-redis_linux_{version}_amd64.tar.gz","source_format":"tar.gz","keep_files":["var/db/newrelic-infra/newrelic-integrations/bin/nri-redis"]},
@@ -31,5 +30,4 @@ jobs:
           {"name":"windows-amd64","os":"windows","arch":"amd64","format":"zip","source_asset":"nri-redis-amd64.{version}.zip","source_format":"zip","keep_files":["New Relic/newrelic-infra/newrelic-integrations/bin/nri-redis.exe"]}
         ]
       source_repo: "newrelic/nri-redis"
-      metadata_git_ref: "master"
     secrets: inherit


### PR DESCRIPTION
## Why

Clients can use new relic control, to install and manage agents in their infrastructure. We have already NRInfra, NRDot and some more.

We are working now on giving support for OHI's. So clients can manage their redis,postgresql etc... and push configuration changes through the agent control.

## What

1. Calls the `reusable_agent_control_release` workflow
2. Has some metadata of the OHI
- It `Requires` infrastructure-agent to work
- it requires at least certain version of AgentControl to be installed
- We have the agent-types (the `windows.yml` and `linux.yml`) that define what variables we can send and how/where the binaries are stored and used.

## Notes
Right now, agent-control doesn't support OHI for now, so the agent-types files can (and will) change, that's why I set the PR as draft to get comments, but it's not fully finished.

Docs on how [onboarding of new agents](https://newrelic.atlassian.net/wiki/spaces/INST/pages/5813207523/Documentation+-+Onboarding+agents+to+Instrumentation+metadata?atlOrigin=eyJpIjoiMTg3NDE2ZGM3MWZhNDk3NDlhZjA2NmQxNDliMTVkZWMiLCJwIjoiY29uZmx1ZW5jZS1jaGF0cy1pbnQifQ)