### PR TITLE
fix: include LICENSE and THIRD_PARTY_NOTICES.md in archive releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
-### 🐛 Bug fixes
+### 🐞 Bug fixes
 - Include `LICENSE` and `THIRD_PARTY_NOTICES.md` in the `.tar.gz` and `.zip` release archives, matching the `.deb`/`.rpm` packages
 
 ## v1.15.2 - 2026-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 ## Unreleased
 
 ### 🐞 Bug fixes
-- Include `LICENSE` and `THIRD_PARTY_NOTICES.md` in the `.tar.gz` and `.zip` release archives, matching the `.deb`/`.rpm` packages
+- Include LICENSE and THIRD_PARTY_NOTICES.md in the .tar.gz and .zip release archives, matching the .deb/.rpm packages
 
 ## v1.15.2 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
+### 🐛 Bug fixes
+- Include `LICENSE` and `THIRD_PARTY_NOTICES.md` in the `.tar.gz` and `.zip` release archives, matching the `.deb`/`.rpm` packages
+
 ## v1.15.2 - 2026-07-13
 
 ### ⛓️ Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
-### 🐞 Bug fixes
+### bugfix
 - Include LICENSE and THIRD_PARTY_NOTICES.md in the .tar.gz and .zip release archives, matching the .deb/.rpm packages
 
 ## v1.15.2 - 2026-07-13

--- a/build/.goreleaser.yml
+++ b/build/.goreleaser.yml
@@ -158,6 +158,8 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
       - redis-config.yml.sample
+      - LICENSE
+      - THIRD_PARTY_NOTICES.md
       - src: 'legacy/redis-definition.yml'
         dst: .
         strip_parent: true
@@ -169,6 +171,8 @@ archives:
     name_template: "{{ .ProjectName }}-fips_{{ .Os }}_{{ .Version }}_{{ .Arch }}_dirty"
     files:
       - redis-config.yml.sample
+      - LICENSE
+      - THIRD_PARTY_NOTICES.md
       - src: 'legacy/redis-definition.yml'
         dst: .
         strip_parent: true
@@ -180,6 +184,8 @@ archives:
     name_template: "{{ .ProjectName }}-{{ .Arch }}.{{ .Version }}_dirty"
     files:
       - redis-config.yml.sample
+      - LICENSE
+      - THIRD_PARTY_NOTICES.md
       - src: 'legacy/redis-win-definition.yml'
         dst: .
         strip_parent: true


### PR DESCRIPTION
The .tar.gz and .zip release archives omitted LICENSE and THIRD_PARTY_NOTICES.md, unlike the .deb/.rpm packages which include them via nfpms.contents. Since `release.disable: true` is set (a custom publisher handles signing/uploading), release.extra_files has no effect, so the files must be added directly to archives.files.

Added both files to all three archive targets: nri-nix, nri-nix-fips, and nri-win.

Fixes NR-599742